### PR TITLE
Fix hybrid name editor

### DIFF
--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -482,6 +482,14 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
     let didSwitchToHand = false;
 
     const handlePointerDown = (e: PointerEvent) => {
+      if (document.body.classList.contains('rename-overlay-active')) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+      if (target.closest?.('[data-is-ui="true"]')) return;
+
+      console.log(`[CanvasArea] pointerdown type=${e.pointerType} src=${target.constructor.name}`);
       const { penMode } = useFileSystemStore.getState();
       const currentTool = editor.getCurrentToolId();
 
@@ -499,6 +507,11 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
     };
 
     const handlePointerUp = (e: PointerEvent) => {
+      if (document.body.classList.contains('rename-overlay-active')) return;
+
+      const target = e.target as HTMLElement;
+      if (target.closest?.('[data-is-ui="true"]')) return;
+      console.log(`[CanvasArea] pointerup type=${e.pointerType} target=${target.tagName}#${target.id}.${target.className}`);
       if (activeTouchIds.has(e.pointerId)) {
         activeTouchIds.delete(e.pointerId);
 

--- a/src/components/Canvas/CanvasTitle.module.css
+++ b/src/components/Canvas/CanvasTitle.module.css
@@ -43,37 +43,24 @@
   font-size: 0.9rem;
   font-weight: normal;
   letter-spacing: normal;
-  padding: 0 8px;
 }
 
-/* Breadcrumb text is subtle but readable */
-.breadcrumb .itemWrapper .nameText {
-  opacity: 0.8;
-}
-
-/* Drawings follow text opacity */
-.breadcrumb .itemWrapper .strokeOverlay {
-  opacity: 0.8;
+/* Breadcrumb items are subtle by default */
+.breadcrumb .itemWrapper {
+  opacity: 0.6;
+  color: hsl(var(--color-text-secondary));
 }
 
 /* The last item (active page) should be prominent */
-.container>.itemWrapper:last-of-type,
 .breadcrumb>.itemWrapper:last-of-type {
   opacity: 1;
-  color: var(--color-accent);
-}
-
-.container>.itemWrapper:last-of-type .nameText,
-.breadcrumb>.itemWrapper:last-of-type .nameText,
-.container>.itemWrapper:last-of-type .strokeOverlay,
-.breadcrumb>.itemWrapper:last-of-type .strokeOverlay {
-  opacity: 1;
+  color: var(--color-accent) !important;
 }
 
 .separator {
   opacity: 0.3;
   font-size: 0.9rem;
-  margin: 0;
+  margin: 0 4px;
   color: hsl(var(--color-text-secondary));
 }
 
@@ -92,7 +79,7 @@
 .strokeOverlay {
   position: absolute;
   top: 0;
-  insetInlineStart: 0;
+  insetInlineStart: 8px;
   /* changed from left: 0 */
   width: 100%;
   height: 100%;

--- a/src/components/Canvas/CanvasTitle.tsx
+++ b/src/components/Canvas/CanvasTitle.tsx
@@ -2,51 +2,13 @@ import { useMemo, Fragment } from 'react';
 import { useFileSystemStore } from '../../store/fileSystemStore';
 import { useTranslation } from 'react-i18next';
 import styles from './CanvasTitle.module.css';
-import { getSvgPathBoundingBox } from '../../lib/svgUtils';
+import { HybridName } from '../UI/HybridName';
 
 interface PathItem {
   id: string;
   name: string;
   nameStrokes?: string;
 }
-
-const HybridPathItem = ({ item, isRtl }: { item: PathItem; isRtl: boolean }) => {
-  const bbox = useMemo(() => {
-    if (!item.nameStrokes) return null;
-    return getSvgPathBoundingBox(item.nameStrokes);
-  }, [item.nameStrokes]);
-
-  const drawingWidth = (bbox && !bbox.isEmpty) ? bbox.x + bbox.width : 0;
-  const svgWidth = Math.max(250, drawingWidth);
-  const viewBox = `0 0 ${svgWidth} 40`;
-
-  return (
-    <div className={styles.itemWrapper}>
-      <span className={styles.nameText}>{item.name}</span>
-      {item.nameStrokes && (
-        <div className={styles.drawingSpacer} style={{ width: drawingWidth }}>
-          <div className={styles.strokeOverlay}>
-            <svg
-              viewBox={viewBox}
-              width={svgWidth}
-              height={40}
-              style={{ display: 'block' }}
-            >
-              <path
-                d={item.nameStrokes}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                transform={isRtl ? `translate(${svgWidth - drawingWidth}, 0)` : undefined}
-              />
-            </svg>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
 
 export const CanvasTitle = () => {
   const { t, i18n } = useTranslation();
@@ -89,7 +51,12 @@ export const CanvasTitle = () => {
       <div className={styles.breadcrumb} onClick={toggleSidebar} title={t('click_to_show_sidebar')}>
         {breadcrumbItems.map((item, i) => (
           <Fragment key={item.id}>
-            <HybridPathItem item={item} isRtl={isRtl} />
+            <HybridName
+              name={item.name}
+              strokes={item.nameStrokes}
+              isRtl={isRtl}
+              className={styles.itemWrapper}
+            />
             {i < breadcrumbItems.length - 1 && <span className={styles.separator}>/</span>}
           </Fragment>
         ))}

--- a/src/components/Sidebar/DeleteConfirmModal.module.css
+++ b/src/components/Sidebar/DeleteConfirmModal.module.css
@@ -57,7 +57,6 @@
   align-items: center;
   position: relative;
   height: 2.5rem;
-  padding: 0 8px;
   overflow: hidden;
 }
 

--- a/src/components/Sidebar/DeleteConfirmModal.tsx
+++ b/src/components/Sidebar/DeleteConfirmModal.tsx
@@ -1,9 +1,8 @@
 import { createPortal } from 'react-dom';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Book, Folder as FolderIcon, File } from 'lucide-react';
 import styles from './DeleteConfirmModal.module.css';
-import { getSvgPathBoundingBox } from '../../lib/svgUtils';
+import { HybridName } from '../UI/HybridName';
 
 interface DeleteConfirmModalProps {
   isOpen: boolean;
@@ -16,54 +15,13 @@ interface DeleteConfirmModalProps {
 }
 
 export const DeleteConfirmModal = ({ isOpen, itemName, itemStrokes, itemType, itemCount, onConfirm, onCancel }: DeleteConfirmModalProps) => {
+  const { t } = useTranslation();
   if (!isOpen) return null;
-
-
-  const bbox = useMemo(() => {
-    if (!itemStrokes) return null;
-    return getSvgPathBoundingBox(itemStrokes);
-  }, [itemStrokes]);
-
-  const hasText = itemName && itemName.length > 0;
-
-  let svgStyle = undefined;
-  let viewBox = undefined;
-
-  if (bbox && !bbox.isEmpty) {
-    if (hasText) {
-      // If we have text, we must mimic the sidebar layout (0-250 coordinate space)
-      // We start from x=0 to preserve horizontal alignment relative to text.
-      // We extend width to cover the full drawing (bbox.x + bbox.width).
-      const fullWidth = bbox.x + bbox.width;
-      const height = 40; // Sidebar items are fixed 40px height
-
-      svgStyle = {
-        width: `${fullWidth}px`,
-        height: `${height}px`,
-      };
-
-      // We view from (0,0) to include the left whitespace relative to text start
-      viewBox = `0 0 ${fullWidth} ${height}`;
-    } else {
-      // If no text (handwriting mainly), we crop tightly to the drawing to save space
-      svgStyle = {
-        width: `${bbox.width}px`,
-        height: `${bbox.height}px`,
-        minWidth: `${bbox.width}px`
-      };
-
-      viewBox = `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`;
-    }
-  }
-
 
   let Icon = File;
   if (itemType === 'notebook') Icon = Book;
   if (itemType === 'folder') Icon = FolderIcon;
 
-  const { t } = useTranslation(); // Need to add hook usage at top component level
-  // Actually I need to add useTranslation import and hook usage first.
-  // Let's do a multi-edit for the whole file or just the render part.
   const itemDescriptionKey = itemType === 'notebook' ? 'notebook' : itemType === 'folder' ? 'folder' : 'page';
 
   return createPortal(
@@ -76,26 +34,11 @@ export const DeleteConfirmModal = ({ isOpen, itemName, itemStrokes, itemType, it
 
         <div className={styles.itemReplica}>
           <Icon size={16} className={styles.icon} />
-          <div className={styles.itemName}>
-            <span className={styles.nameText}>{itemName}</span>
-            {itemStrokes && (
-              <div className={styles.strokeClip}>
-                <svg
-                  className={styles.nameStrokes}
-                  viewBox={viewBox}
-                  style={{
-                    ...svgStyle,
-                    position: 'absolute',
-                    top: 0,
-                    insetInlineStart: '0',
-                    maxWidth: 'none'
-                  }}
-                >
-                  <path d={itemStrokes} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
-              </div>
-            )}
-          </div>
+          <HybridName
+            name={itemName}
+            strokes={itemStrokes}
+            className={styles.itemName}
+          />
         </div>
 
         <div className={styles.buttons}>

--- a/src/components/Sidebar/RenameOverlay.module.css
+++ b/src/components/Sidebar/RenameOverlay.module.css
@@ -6,7 +6,8 @@
   height: 100vh;
   z-index: 1000;
   background: rgba(0, 0, 0, 0.1);
-  /* Subtle backdrop to focus */
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .overlay {
@@ -18,7 +19,11 @@
   box-shadow: var(--shadow-lg);
   padding: 1rem;
   overflow: visible;
-  /* Removed backdrop-filter as requested */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .container {
@@ -26,48 +31,96 @@
   flex-direction: column;
   gap: 0.5rem;
   position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .inputWrapper {
   position: relative;
-  height: 5rem;
-  /* 80px (2x height of sidebar item) */
+  height: 80px;
+  /* Exactly 2.0x Sidebar height */
   display: flex;
   align-items: center;
   background: hsl(var(--color-bg-secondary));
   /* Solid background, no transparency */
   border-radius: var(--radius-sm);
-  padding: 0 16px;
-  /* 8px * 2 */
-  border: 1px solid hsl(var(--color-text-secondary) / 0.1);
+  padding: 0;
+  /* Marginal Logic moved to children */
+  box-sizing: border-box;
   touch-action: none;
 }
 
 .input {
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 17px;
+  width: calc(100% - 34px);
+  height: 80px;
+  line-height: 80px;
   border: none;
   background: transparent;
-  font-family: inherit;
-  font-size: 1.8rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 28px;
   font-weight: normal;
-  letter-spacing: normal;
-  /* 0.9rem * 2 */
+  letter-spacing: 0;
+  text-rendering: geometricPrecision;
+  font-variant-ligatures: none;
+  font-kerning: none;
   padding: 0;
+  margin: 0;
   color: inherit;
-  /* inherit from wrapper which gets color from prop */
-  /* Ensure high contrast */
+  caret-color: currentColor;
   outline: none;
+  z-index: 10;
+  white-space: nowrap;
 }
 
 .svgOverlay {
   position: absolute;
   top: 0;
-  left: 16px;
-  /* 8px * 2 */
-  width: calc(100% - 32px);
+  left: 17px;
+  /* 1px border + 16px padding */
+  width: calc(100% - 34px);
   height: 100%;
   pointer-events: none;
+}
+
+.textModeDrawing {
+  position: absolute !important;
+  top: 0;
+  left: 17px;
+  width: calc(100% - 34px);
+  height: 100%;
+  pointer-events: none;
+  z-index: 5;
+  opacity: 0.6;
+}
+
+.penModeBackground {
+  position: absolute !important;
+  top: 0;
+  left: 17px;
+  width: calc(100% - 34px);
+  height: 100%;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.penModeName {
+  flex: 1;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: normal;
+  letter-spacing: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: inherit;
+  transform: scale(2);
+  transform-origin: left center;
+  height: 20px;
+  /* 40px visual / 2 */
 }
 
 
@@ -86,6 +139,7 @@
   width: 100%;
   height: 100%;
   cursor: crosshair;
+  z-index: 10;
 }
 
 .actions {

--- a/src/components/Sidebar/RenameOverlay.tsx
+++ b/src/components/Sidebar/RenameOverlay.tsx
@@ -1,9 +1,9 @@
-
-import React, { useState, useRef, useEffect } from 'react';
+import { useRef, useEffect, useLayoutEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './RenameOverlay.module.css';
-import { X, Eraser } from 'lucide-react';
 import { DefaultColorThemePalette } from 'tldraw';
+import { RenameOverlayTextMode } from './RenameOverlayTextMode';
+import { RenameOverlayPenMode } from './RenameOverlayPenMode';
 
 interface RenameOverlayProps {
   initialName: string;
@@ -15,31 +15,68 @@ interface RenameOverlayProps {
   initialPointerType?: string;
 }
 
-export const RenameOverlayV2 = ({ initialName, initialStrokes, initialColor, onSave, onCancel, anchorRect, initialPointerType = 'mouse' }: RenameOverlayProps) => {
-  const [name, setName] = useState(initialName);
-  const [paths, setPaths] = useState<string[]>(initialStrokes ? [initialStrokes] : []);
-  const [currentPath, setCurrentPath] = useState<string>("");
-  const [selectedColor, setSelectedColor] = useState<string>(initialColor || 'auto');
-  const [scrollLeft, setScrollLeft] = useState(0);
-  const [lastPointerType, setLastPointerType] = useState<string>('mouse');
-  const isDrawing = useRef(false);
+export const RenameOverlayV2 = ({
+  initialName,
+  initialStrokes,
+  initialColor,
+  onSave,
+  onCancel,
+  anchorRect,
+  initialPointerType = 'mouse'
+}: RenameOverlayProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const scrollGroupRef = useRef<SVGGElement>(null);
 
-  // Use DefaultColorThemePalette logic directly since we are outside Tldraw context
-  // We can just rely on basic "light" mode palette for mapping, or CSS vars.
-  // Actually, we want to know if it is dark mode to pick the right HEX for the swatch background.
-  // Since we are outside Tldraw, we can check the 'data-theme' attribute on the document element or use a media query.
-  // But simpler: just use CSS variables for background colors of swatches, or map them to the Palette.
+
+  // Add a class to body to help CanvasArea and others know we are editing
+  useLayoutEffect(() => {
+    document.body.classList.add('rename-overlay-active');
+
+    // Aggressively kill system gestures on body
+    const oldTouchAction = document.body.style.touchAction;
+    const oldUserSelect = document.body.style.userSelect;
+    const oldWebkitUserSelect = document.body.style.webkitUserSelect;
+
+    document.body.style.touchAction = 'none';
+    document.body.style.userSelect = 'none';
+    document.body.style.webkitUserSelect = 'none';
+
+    return () => {
+      document.body.classList.remove('rename-overlay-active');
+      document.body.style.touchAction = oldTouchAction;
+      document.body.style.userSelect = oldUserSelect;
+      document.body.style.webkitUserSelect = oldWebkitUserSelect;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+
+    window.addEventListener('keydown', handleGlobalKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleGlobalKeyDown);
+    };
+  }, [onCancel]);
+
+
+
+  // Position logic
+  const width = 450;
+  const height = 165;
+  const margin = 10;
+  let top = anchorRect.top - (height - anchorRect.height) / 2;
+  let left = anchorRect.left - (width - anchorRect.width) / 2;
+  top = Math.max(margin, Math.min(top, window.innerHeight - height - margin));
+  left = Math.max(margin, Math.min(left, window.innerWidth - width - margin));
+
+  // Theme & Colors
   const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark' ||
     (document.documentElement.getAttribute('data-theme') === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-
   const theme = isDarkMode ? DefaultColorThemePalette.darkMode : DefaultColorThemePalette.lightMode;
-
-  // Colors mapping (using Tldraw's actual theme engine)
   const colorsMap: Record<string, string> = {
-    auto: theme.black.solid, // Represents "Auto" / Inherit
+    auto: theme.black.solid,
     grey: theme.grey.solid,
     blue: theme.blue.solid,
     red: theme.red.solid,
@@ -48,126 +85,39 @@ export const RenameOverlayV2 = ({ initialName, initialStrokes, initialColor, onS
     violet: theme.violet.solid,
   };
 
-  // Position logic: centered over the anchor, but slightly larger
-  const width = 450; // Increased from 340
-  const height = 165; // Adjusted to be even tighter per user request
-  const margin = 10;
+  const isPenMode = initialPointerType === 'pen';
 
-  let top = anchorRect.top - (height - anchorRect.height) / 2;
-  let left = anchorRect.left - (width - anchorRect.width) / 2;
+  const [name, setName] = useState(initialName);
+  const [strokes, setStrokes] = useState(initialStrokes);
+  const [selectedColor, setSelectedColor] = useState<string>(initialColor || 'auto');
 
-  // Clamp to viewport
-  top = Math.max(margin, Math.min(top, window.innerHeight - height - margin));
-  left = Math.max(margin, Math.min(left, window.innerWidth - width - margin));
-
-  useEffect(() => {
-    const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        onSave(name, paths.join(' '), selectedColor);
-      }
-    };
-    window.addEventListener('keydown', handleGlobalKeyDown);
-    return () => window.removeEventListener('keydown', handleGlobalKeyDown);
-  }, [name, paths, selectedColor, onCancel, onSave]);
-
-  const handleScroll = (e: React.UIEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    const sl = e.currentTarget.scrollLeft;
-    setScrollLeft(sl);
-    if (scrollGroupRef.current) {
-      scrollGroupRef.current.setAttribute('transform', `translate(${-sl}, 0)`);
-    }
+  const handleSave = () => {
+    // Trim whitespaces as requested
+    onSave(name.trim(), strokes, selectedColor);
   };
 
-  const startDrawing = (e: React.PointerEvent) => {
-    // Only allow drawing with pen
-    if (e.pointerType !== 'pen') return;
-
-    // For pen/touch, we prevent default to stop focus/text selection on the input below
-    e.preventDefault();
-    e.stopPropagation();
-
-    // Ensure clean state before starting
-    if (isDrawing.current) {
-      // Finish any pending stroke first
-      if (currentPath) {
-        setPaths(prev => [...prev, currentPath]);
-      }
-    }
-
-    try {
-      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    } catch {
-      // Pointer capture might fail in some scenarios, continue anyway
-    }
-
-    isDrawing.current = true;
-    const pos = getPos(e);
-    // pos.x is relative to inputWrapper padding start now
-    setCurrentPath(`M ${pos.x} ${pos.y}`);
+  const handleClear = () => {
+    setName('');
+    setStrokes(undefined);
   };
-
-  const draw = (e: React.PointerEvent) => {
-    e.stopPropagation();
-    setLastPointerType(e.pointerType);
-    if (!isDrawing.current) return;
-    if (e.pointerType === 'pen') e.preventDefault();
-    const pos = getPos(e);
-    setCurrentPath(prev => `${prev} L ${pos.x} ${pos.y}`);
-  };
-
-  const stopDrawing = (e: React.PointerEvent) => {
-    e.stopPropagation();
-    if (isDrawing.current && currentPath) {
-      setPaths(prev => [...prev, currentPath]);
-      setCurrentPath("");
-    }
-    isDrawing.current = false;
-    if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
-      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-    }
-  };
-
-  const getPos = (e: React.PointerEvent) => {
-    // Crucial: Use the inputWrapper (currentTarget) or containerRef for coordinates
-    // If listeners are on inputWrapper, currentTarget is inputWrapper.
-    // However, if we draw over the input, the rect should be relative to where the SVG starts.
-    const wrapper = containerRef.current?.querySelector(`.${styles.inputWrapper}`);
-    const rect = wrapper?.getBoundingClientRect();
-    if (!rect) return { x: 0, y: 0 };
-
-    // SVG coordinate space is 1x (height 40). UI is 2x (height 80).
-    // Padding 16px in UI = 8px in SVG space.
-    const SCALE = 2;
-    return {
-      x: (e.clientX - rect.left - 16 + scrollLeft) / SCALE,
-      y: (e.clientY - rect.top) / SCALE
-    };
-  };
-
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) onCancel();
-  };
-
-  // Sync scroll on text change (input auto-scrolls when typing)
-  useEffect(() => {
-    if (inputRef.current) {
-      const sl = inputRef.current.scrollLeft;
-      setScrollLeft(sl);
-      if (scrollGroupRef.current) {
-        scrollGroupRef.current.setAttribute('transform', `translate(${-sl}, 0)`);
-      }
-    }
-  }, [name]);
-
-
 
   return createPortal(
-    <div className={styles.backdrop} onClick={handleOverlayClick}>
+    <div
+      className={styles.backdrop}
+      data-is-ui="true"
+      onPointerDown={(e) => {
+        // Close if click is on the backdrop itself
+        if (e.target === e.currentTarget) onCancel();
+        e.stopPropagation();
+      }}
+      onPointerMove={(e) => e.stopPropagation()}
+      onPointerUp={(e) => e.stopPropagation()}
+      onPointerCancel={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.preventDefault()}
+    >
       <div
         className={styles.overlay}
+        data-is-ui="true"
         style={{
           top: `${top}px`,
           left: `${left}px`,
@@ -175,104 +125,39 @@ export const RenameOverlayV2 = ({ initialName, initialStrokes, initialColor, onS
           height: `${height}px`
         }}
         ref={containerRef}
-        onClick={(e) => e.stopPropagation()} // Stop propagation from clicking inside the overlay
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+        }}
+        onPointerMove={(e) => e.stopPropagation()}
+        onPointerUp={(e) => e.stopPropagation()}
+        onPointerCancel={(e) => e.stopPropagation()}
+        onContextMenu={(e) => e.preventDefault()}
       >
-        <div className={styles.container}>
-          <div
-            className={styles.inputWrapper}
-            onPointerDown={startDrawing}
-            onPointerMove={draw}
-            onPointerUp={stopDrawing}
-            onPointerLeave={(e) => {
-              if (e.pointerType !== 'pen') stopDrawing(e);
-            }}
-            onPointerEnter={(e) => {
-              e.stopPropagation();
-              setLastPointerType(e.pointerType);
-            }}
-            style={{
-              cursor: lastPointerType === 'pen' ? 'crosshair' : 'text',
-              direction: 'ltr', /* Force LTR for the coordinate system to match SVG, but handle visual RTL via CSS */
-              touchAction: 'none',
-              userSelect: initialPointerType === 'pen' ? 'none' : 'auto',
-              WebkitUserSelect: initialPointerType === 'pen' ? 'none' : 'auto',
-              WebkitTouchCallout: initialPointerType === 'pen' ? 'none' : 'auto',
-            } as React.CSSProperties}
-          >
-            <input
-              ref={inputRef}
-              autoFocus={initialPointerType !== 'pen'}
-              className={styles.input}
-              value={name}
-              readOnly={initialPointerType === 'pen'}
-              onFocus={(e) => {
-                if (initialPointerType !== 'pen') {
-                  e.target.select();
-                }
-                // In pen mode, we don't handle focus at all to avoid interference
-              }}
-              onChange={(e) => setName(e.target.value)}
-              onScroll={handleScroll}
-              style={{
-                cursor: initialPointerType === 'pen' ? 'default' : 'text',
-                textAlign: 'start',
-                pointerEvents: initialPointerType === 'pen' ? 'none' : 'auto'
-              }}
-            />
-            <svg className={styles.svgOverlay} viewBox="0 0 2000 40" preserveAspectRatio="xMinYMin slice">
-              {/* The strokes AND the guide move with the text scroll */}
-              <g ref={scrollGroupRef} transform={`translate(${-scrollLeft / 2}, 0)`}>
-                {/* Visible Area Guide - now anchored to text start */}
-                <rect
-                  x="0"
-                  y="0"
-                  width="140"
-                  height="40"
-                  rx="4"
-                  className={styles.guideRect}
-                />
-                {paths.map((p, i) => <path key={i} d={p} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />)}
-                {currentPath && <path d={currentPath} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />}
-              </g>
-            </svg>
-
-          </div>
-
-          <div className={styles.actions}>
-            <div className={styles.colorsRow}>
-              {Object.entries(colorsMap).map(([key, hex]) => (
-                <button
-                  key={key}
-                  className={styles.colorSwatch}
-                  style={{
-                    backgroundColor: hex,
-                    boxShadow: selectedColor === key
-                      ? `0 0 0 2px hsl(var(--color-bg-primary)), 0 0 0 4px ${hex}`
-                      : undefined
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setSelectedColor(key);
-                  }}
-                  title={key === 'auto' ? 'Auto' : key}
-                >
-                  {/* Visual cue for auto handled by box-shadow or just plain */}
-                </button>
-              ))}
-            </div>
-
-            <div className={styles.buttonsGroup}>
-              <button className={styles.btn} onClick={(e) => { e.stopPropagation(); setName(""); setPaths([]); }} title="Clear All"><Eraser size={20} /></button>
-              <button className={styles.btn} onClick={(e) => { e.stopPropagation(); onCancel(); }} title="Cancel"><X size={20} /></button>
-              <button
-                className={styles.confirm}
-                onClick={(e) => { e.stopPropagation(); onSave(name, paths.join(' '), selectedColor); }}
-              >
-                SAVE
-              </button>
-            </div>
-          </div>
-        </div>
+        {isPenMode ? (
+          <RenameOverlayPenMode
+            name={name}
+            strokes={strokes}
+            setStrokes={setStrokes}
+            selectedColor={selectedColor}
+            setSelectedColor={setSelectedColor}
+            onSave={handleSave}
+            onClear={handleClear}
+            colorsMap={colorsMap}
+          />
+        ) : (
+          <RenameOverlayTextMode
+            name={name}
+            setName={setName}
+            strokes={strokes}
+            selectedColor={selectedColor}
+            setSelectedColor={setSelectedColor}
+            onSave={handleSave}
+            onClear={handleClear}
+            onCancel={onCancel}
+            colorsMap={colorsMap}
+          />
+        )}
       </div>
     </div>,
     document.body

--- a/src/components/Sidebar/RenameOverlayPenMode.tsx
+++ b/src/components/Sidebar/RenameOverlayPenMode.tsx
@@ -1,0 +1,205 @@
+import React, { useRef, useEffect } from 'react';
+import styles from './RenameOverlay.module.css';
+import { X } from 'lucide-react';
+import { HybridName } from '../UI/HybridName';
+
+interface RenameOverlayPenModeProps {
+  name: string;
+  strokes?: string;
+  setStrokes: (strokes: string | undefined) => void;
+  selectedColor: string;
+  setSelectedColor: (color: string) => void;
+  onSave: () => void;
+  onClear: () => void;
+  colorsMap: Record<string, string>;
+}
+
+export const RenameOverlayPenMode = ({
+  name,
+  strokes,
+  setStrokes,
+  selectedColor,
+  setSelectedColor,
+  onSave,
+  onClear,
+  colorsMap
+}: RenameOverlayPenModeProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isDrawing = useRef(false);
+  const currentPathPoints = useRef<{ x: number; y: number }[]>([]);
+  const currentPaths = useRef<string[]>([]);
+
+  // Initialize canvas and draw initial strokes
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const cssWidth = rect.width || 418;
+    const cssHeight = rect.height || 80;
+    const scale = cssHeight / 40; // Usually 2.0
+
+    // Setup HiDPI and global translation
+    canvas.width = cssWidth * dpr;
+    canvas.height = cssHeight * dpr;
+    ctx.scale(dpr * scale, dpr * scale);
+    ctx.translate(8.5, 0); // Always stay shifted to text start (17px / 2 = 8.5)
+
+    // Set drawing styles
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = 2;
+
+    // Clear canvas before redrawing
+    ctx.clearRect(-8, 0, canvas.width / (dpr * scale), canvas.height / (dpr * scale));
+
+    // Draw strokes from prop (no need to save/restore translate)
+    if (strokes) {
+      const segments = strokes.split('M').filter(s => s.trim());
+      segments.forEach(seg => {
+        const points = seg.split('L').map(p => {
+          const coords = p.trim().split(' ');
+          if (coords.length < 2) return null;
+          return { x: Number(coords[0]), y: Number(coords[1]) };
+        }).filter((p): p is { x: number, y: number } => p !== null);
+
+        if (points.length > 0) {
+          ctx.beginPath();
+          ctx.strokeStyle = colorsMap[selectedColor];
+          ctx.moveTo(points[0].x, points[0].y);
+          for (let i = 1; i < points.length; i++) {
+            ctx.lineTo(points[i].x, points[i].y);
+          }
+          ctx.stroke();
+        }
+      });
+      // Sync internal paths ref
+      currentPaths.current = strokes.split('M').filter(s => s.trim()).map(s => 'M' + s);
+    } else {
+      currentPaths.current = [];
+    }
+  }, [strokes, colorsMap, selectedColor]);
+
+  const startDrawing = (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.pointerType !== 'pen') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    // Force scale to exactly 2.0 if we are near 80px to avoid float drift
+    const scale = Math.abs(rect.height - 80) < 2 ? 2.0 : rect.height / 40;
+
+    // x=0 is at rect.left + 1px border + 16px padding
+    // 16px padding / 2.0 scale = 8 units. 
+    // 1px border / 2.0 scale = 0.5 units.
+    const borderOffset = 1 / scale;
+    const x = (e.clientX - rect.left) / scale - 8 - borderOffset;
+    const y = (e.clientY - rect.top) / scale;
+
+    isDrawing.current = true;
+    currentPathPoints.current = [{ x, y }];
+
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.beginPath();
+      ctx.strokeStyle = colorsMap[selectedColor];
+      ctx.moveTo(x, y);
+    }
+  };
+
+  const draw = (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isDrawing.current || e.pointerType !== 'pen') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const scale = 2.0;
+    const x = (e.clientX - rect.left) / scale - 8.5;
+    const y = (e.clientY - rect.top) / scale;
+
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    }
+    currentPathPoints.current.push({ x, y });
+  };
+
+  const stopDrawing = (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isDrawing.current) {
+      isDrawing.current = false;
+      if (currentPathPoints.current.length > 0) {
+        const first = currentPathPoints.current[0];
+        let path = `M ${first.x.toFixed(2)} ${first.y.toFixed(2)}`;
+        for (let i = 1; i < currentPathPoints.current.length; i++) {
+          path += ` L ${currentPathPoints.current[i].x.toFixed(2)} ${currentPathPoints.current[i].y.toFixed(2)}`;
+        }
+        const updatedPaths = [...currentPaths.current, path];
+        setStrokes(updatedPaths.join(' '));
+      }
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputWrapper} style={{ color: colorsMap[selectedColor] }}>
+        <HybridName
+          name={name || ' '}
+          strokes={undefined}
+          scale={2}
+          isEditor={true}
+          className={styles.penModeBackground}
+        />
+        <canvas
+          ref={canvasRef}
+          className={styles.canvas}
+          onPointerDown={startDrawing}
+          onPointerMove={draw}
+          onPointerUp={stopDrawing}
+          onPointerCancel={stopDrawing}
+          onLostPointerCapture={stopDrawing}
+          onTouchStart={(e) => e.preventDefault()}
+          onTouchMove={(e) => e.preventDefault()}
+          onTouchEnd={(e) => e.preventDefault()}
+          onTouchCancel={(e) => e.preventDefault()}
+        />
+      </div>
+
+      <div className={styles.actions}>
+        <div className={styles.colorsRow}>
+          {Object.entries(colorsMap).map(([cName, hex]) => (
+            <button
+              key={cName}
+              className={styles.colorSwatch}
+              style={{
+                backgroundColor: hex,
+                outline: selectedColor === cName ? '2px solid var(--color-accent)' : 'none',
+                outlineOffset: '2px'
+              }}
+              onClick={() => setSelectedColor(cName)}
+              title={cName}
+            />
+          ))}
+        </div>
+
+        <div className={styles.buttonsGroup}>
+          <button className={styles.btn} onClick={onClear} title="Clear All">
+            <X size={20} />
+          </button>
+          <button className={styles.confirm} onClick={onSave}>
+            SAVE
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Sidebar/RenameOverlayTextMode.tsx
+++ b/src/components/Sidebar/RenameOverlayTextMode.tsx
@@ -1,0 +1,110 @@
+import { useState, useRef, useEffect } from 'react';
+import { HybridName } from '../UI/HybridName';
+import styles from './RenameOverlay.module.css';
+import { X } from 'lucide-react';
+
+interface RenameOverlayTextModeProps {
+  name: string;
+  setName: (name: string) => void;
+  strokes?: string;
+  selectedColor: string;
+  setSelectedColor: (color: string) => void;
+  onSave: () => void;
+  onClear: () => void;
+  onCancel: () => void;
+  colorsMap: Record<string, string>;
+}
+
+export const RenameOverlayTextMode = ({
+  name,
+  setName,
+  strokes,
+  selectedColor,
+  setSelectedColor,
+  onSave,
+  onClear,
+  onCancel,
+  colorsMap
+}: RenameOverlayTextModeProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  const handleScroll = () => {
+    if (inputRef.current) {
+      setScrollLeft(inputRef.current.scrollLeft);
+    }
+  };
+
+  useEffect(() => {
+    // Initial sync and periodic check for focus-driven scrolls
+    const timer = setInterval(handleScroll, 100);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputWrapper} style={{ color: colorsMap[selectedColor] }}>
+        <HybridName
+          name={name || ' '}
+          strokes={strokes}
+          color={colorsMap[selectedColor]}
+          className={styles.textModeDrawing}
+          scale={2}
+          isRtl={false}
+          hideText={true}
+          isEditor={true}
+          scrollLeft={scrollLeft}
+        />
+        <input
+          ref={inputRef}
+          autoFocus
+          className={styles.input}
+          value={name}
+          onFocus={(e) => {
+            e.target.select();
+            handleScroll();
+          }}
+          onChange={(e) => {
+            setName(e.target.value);
+            // Scroll usually doesn't update until next frame
+            setTimeout(handleScroll, 0);
+          }}
+          onScroll={handleScroll}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onSave();
+            if (e.key === 'Escape') onCancel();
+          }}
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </div>
+
+      <div className={styles.actions}>
+        <div className={styles.colorsRow}>
+          {Object.entries(colorsMap).map(([cName, hex]) => (
+            <button
+              key={cName}
+              className={styles.colorSwatch}
+              style={{
+                backgroundColor: hex,
+                outline: selectedColor === cName ? '2px solid var(--color-accent)' : 'none',
+                outlineOffset: '2px'
+              }}
+              onClick={() => setSelectedColor(cName)}
+              title={cName}
+            />
+          ))}
+        </div>
+
+        <div className={styles.buttonsGroup}>
+          <button className={styles.btn} onClick={onClear} title="Clear All">
+            <X size={20} />
+          </button>
+          <button className={styles.confirm} onClick={onSave}>
+            SAVE
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -218,9 +218,7 @@
   overflow: hidden;
   display: flex;
   align-items: center;
-  height: 2rem;
-  padding: 0 8px;
-  /* Standardize padding */
+  height: 40px;
 }
 
 .nameText {

--- a/src/components/UI/HybridName.module.css
+++ b/src/components/UI/HybridName.module.css
@@ -1,0 +1,57 @@
+.container {
+  display: flex;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.nameText {
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: inherit;
+  font-weight: normal;
+  letter-spacing: 0;
+  text-rendering: geometricPrecision;
+  color: inherit;
+  z-index: 1;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Editor mode overrides */
+.container.editor {
+  display: block;
+}
+
+.nameText.editorText {
+  display: inline-block;
+  overflow: visible;
+  text-overflow: clip;
+  flex: none;
+}
+
+.standardWrapper {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.strokeOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* Alignment with text start */
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+  overflow: visible;
+}
+
+.svg {
+  display: block;
+}

--- a/src/components/UI/HybridName.tsx
+++ b/src/components/UI/HybridName.tsx
@@ -1,0 +1,159 @@
+import { useMemo } from 'react';
+import styles from './HybridName.module.css';
+import { getSvgPathBoundingBox } from '../../lib/svgUtils';
+import { clsx } from 'clsx';
+
+interface HybridNameProps {
+  name: string;
+  strokes?: string;
+  color?: string; // Hex color
+  className?: string;
+  isRtl?: boolean;
+  scale?: number;
+  hideText?: boolean;
+  scrollLeft?: number;
+  isEditor?: boolean;
+  width?: string | number;
+  maxWidth?: string | number;
+}
+
+/**
+ * Standardized component to render text with SVG pen strokes.
+ * USES A 28px/80px REFERENCE SCALE FOR ABSOLUTE LINEAR PRECISION.
+ */
+export const HybridName = ({
+  name,
+  strokes,
+  color,
+  className,
+  isRtl,
+  scale = 1,
+  hideText = false,
+  scrollLeft = 0,
+  isEditor = false,
+  width,
+  maxWidth
+}: HybridNameProps) => {
+  const bbox = useMemo(() => {
+    if (!strokes) return null;
+    return getSvgPathBoundingBox(strokes);
+  }, [strokes]);
+
+  // Width calculation: we ensure at least 250px or the extent of the drawing
+  const drawingWidth = (bbox && !bbox.isEmpty) ? bbox.x + bbox.width : 0;
+  const svgWidth = Math.max(250, drawingWidth);
+  const viewBox = `0 0 ${svgWidth} 40`;
+
+  // Vertical normalization: everything is based on an 80px high reference
+  const referenceScale = 2;
+  const visualAdjustment = scale / referenceScale;
+
+  // LAYOUT ARCHITECTURE:
+  // We ALWAYS render text at 28px/80px (Reference Base) and scale the CONTAINER.
+  // This ensures text metrics are identical across ALL modes, solving linear drift.
+  // In standard UI, we use a "Ghost" span at 14px for accurate layout spacing.
+
+  const innerStyle: React.CSSProperties = {
+    transform: `scale(${visualAdjustment})`,
+    transformOrigin: '0 0',
+    width: 'max-content',
+    minWidth: isEditor ? '1000px' : undefined,
+    height: 80,
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    pointerEvents: 'none',
+    overflow: 'visible'
+  };
+
+  const scrollWrapperStyle: React.CSSProperties = {
+    transform: isEditor ? `translateX(${-scrollLeft / visualAdjustment}px)` : undefined,
+    display: 'block',
+    width: 'max-content',
+    height: '100%',
+    position: 'relative',
+    overflow: 'visible'
+  };
+
+  const textStyle: React.CSSProperties = {
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    fontSize: '28px',
+    fontWeight: 400,
+    letterSpacing: '0',
+    lineHeight: '80px',
+    whiteSpace: 'pre',
+    textRendering: 'geometricPrecision',
+    fontVariantLigatures: 'none',
+    fontKerning: 'none',
+    pointerEvents: 'none',
+    visibility: hideText ? 'hidden' : 'visible'
+  };
+
+  const ghostStyle: React.CSSProperties = {
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    fontSize: `${14 * scale}px`,
+    fontWeight: 400,
+    letterSpacing: '0',
+    lineHeight: `${40 * scale}px`,
+    whiteSpace: 'pre',
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    display: 'inline-block'
+  };
+
+  // Horizontal normalization for stroke-only elements (standard mode only)
+  const horizontalShift = (!isEditor && !name && strokes && bbox) ? -bbox.x : 0;
+
+  // Calculate the visual footprint of the strokes in UI pixels (accounting for shift)
+  const strokesRightBoundary = (bbox && !bbox.isEmpty) ? (bbox.x + bbox.width + horizontalShift) * scale : 0;
+
+  return (
+    <div
+      className={clsx(styles.container, className, isEditor && styles.editor)}
+      style={{
+        height: 40 * scale,
+        ...(color ? { color } : {}),
+        width: width || (isEditor ? '100%' : 'auto'),
+        maxWidth,
+        minWidth: (!isEditor && !width) ? Math.max(0, strokesRightBoundary) : undefined,
+        overflow: 'hidden'
+      }}
+    >
+      {/* Ghost for layout (Standard Mode only) */}
+      {!isEditor && name && (
+        <span style={ghostStyle}>{name}</span>
+      )}
+
+      <div style={innerStyle}>
+        <div style={scrollWrapperStyle}>
+          <span className={clsx(styles.nameText, styles.editorText)} style={textStyle}>{name}</span>
+          {strokes && (
+            <div className={styles.strokeOverlay}>
+              <svg
+                viewBox={viewBox}
+                width={svgWidth}
+                height={40}
+                className={styles.svg}
+                style={{
+                  transform: 'scale(2)',
+                  transformOrigin: '0 0',
+                  color: 'inherit'
+                }}
+              >
+                <path
+                  d={strokes}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  transform={isRtl ? `translate(${svgWidth - drawingWidth + horizontalShift}, 0)` : (horizontalShift ? `translate(${horizontalShift}, 0)` : undefined)}
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -180,27 +180,6 @@ body {
   }
 }
 
-/* Hybrid strokes brightness inversion (preserving color) */
-[data-theme='dark'] [class*="strokeOverlay"],
-[data-theme='dark'] [class*="nameStrokes"],
-[data-theme='dark'] [class*="svgOverlay"] {
-  /* Use absolute black as base so invert(1) produces absolute white. */
-  color: #000000 !important;
-  /* Boost brightness and contrast for "almost black" -> "almost white" conversion */
-  filter: invert(1) hue-rotate(180deg) brightness(1.8) contrast(1.2);
-}
-
-@media (prefers-color-scheme: dark) {
-
-  :root:not([data-theme='light']) [class*="strokeOverlay"],
-  :root:not([data-theme='light']) [class*="nameStrokes"],
-  :root:not([data-theme='light']) [class*="svgOverlay"] {
-    /* Use absolute black as base so invert(1) produces absolute white. */
-    color: #000000 !important;
-    /* Boost brightness and contrast for "almost black" -> "almost white" conversion */
-    filter: invert(1) hue-rotate(180deg) brightness(1.8) contrast(1.2);
-  }
-}
 
 /* Tldraw Accent Color Overrides */
 .tl-theme__light,


### PR DESCRIPTION
Refactored the [HybridName](cci:1://file:///Users/johju/Documents/dev/cuaderno/src/components/UI/HybridName.tsx:19:0-158:2) component to achieve pixel-perfect alignment between text and pen strokes across all UI contexts. 
**Key changes included:**
- **Unified 28px Architecture**: Implemented a "Single Source of Truth" by rendering all text at a 28px reference scale and scaling the container down for the UI. This eliminates the "linear drift" caused by inconsistent sub-pixel rendering at smaller font sizes.
- **Layout Ghost Strategy**: Integrated a hidden 14px span to provide accurate flexbox footprinting in Breadcrumbs/Sidebar, while using absolute positioning for the high-precision 28px rendering layers.
- **Dynamic Content Footprint**: Updated width calculations to account for both text and drawing boundaries, preventing drawings from being clipped when they extend beyond the text.
- **Thematic Integrity**: Improved SVG color inheritance and fixed vertical centering issues in navigation bars.
## Type of Change
- [x] Feature/Enhancement
- [x] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests
## Related Issue
Fixes #19
## Changelog Entry
Achieved pixel-perfect synchronization between text and pen strokes in file names and breadcrumbs. Fixed "linear drift" on long names and resolved layout/clipping issues in the sidebar and navigation path.
## Testing
- **Manual Verification**: Tested long names (e.g., "1 2 3... 11") in Sidebar and Breadcrumbs to ensure zero horizontal drift.
- **Overlay Validation**: Verified 1:1 visual parity between Text Mode and Pen Mode in the Rename Overlay.
- **Theme Testing**: Confirmed correct color inheritance and stroke visibility in both Light and Dark modes.
- **Build**: Passes `npm run build` without errors.