### PR TITLE
fix: improve context menu persistence and enable selection rectangle

### DIFF
--- a/src/components/Canvas/CanvasArea.module.css
+++ b/src/components/Canvas/CanvasArea.module.css
@@ -14,6 +14,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
+  touch-action: none;
 }
 
 .canvasContainer>* {

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -789,7 +789,7 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
       }
     };
 
-    const handlePointerUpForLongpress = () => {
+    const handlePointerUpForLongpress = (e: PointerEvent) => {
       if (longpressTimer) {
         clearTimeout(longpressTimer);
         longpressTimer = null;
@@ -926,10 +926,10 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
     window.addEventListener('keyup', handleKeyUp);
 
     // Longpress event listeners for touch and pen
-    container.addEventListener('pointerdown', handlePointerDownForLongpress);
-    container.addEventListener('pointermove', handlePointerMoveForLongpress);
-    container.addEventListener('pointerup', handlePointerUpForLongpress);
-    container.addEventListener('pointercancel', handlePointerUpForLongpress);
+    container.addEventListener('pointerdown', handlePointerDownForLongpress, { capture: true });
+    container.addEventListener('pointermove', handlePointerMoveForLongpress, { capture: true });
+    container.addEventListener('pointerup', handlePointerUpForLongpress, { capture: true });
+    container.addEventListener('pointercancel', handlePointerUpForLongpress, { capture: true });
 
 
     // --- Gesture Detection (2/3 Finger Tap) ---


### PR DESCRIPTION
## Description
Este PR corrige problemas críticos de interacción táctil en iPad y otros dispositivos con pantalla táctil:

1. **Menú Contextual**: Se ha corregido el comportamiento donde el menú contextual se cerraba inmediatamente al levantar el dedo después de una pulsación larga (longpress). Se han ajustado los manejadores de eventos de puntero para asegurar que el menú permanezca abierto.
2. **Rectángulo de Selección**: Se ha habilitado la funcionalidad de "brocha de selección" que no funcionaba en pantallas táctiles. Al añadir `touch-action: none` al contenedor del lienzo, evitamos que los gestos nativos del navegador (como el scroll en Safari) interfieran con la lógica de selección de TLDraw.

## Type of Change
- [x] Bug Fix

## Related Issue
Fixes #29

## Changelog Entry
- Corregido el cierre prematuro del menú contextual en dispositivos táctiles tras una pulsación larga.
- Habilitado el rectángulo de selección en pantallas táctiles eliminando la interferencia de gestos del navegador.

## Testing
- Verificación de la lógica de propagación y captura de eventos de puntero.
- Validación de la propiedad CSS `touch-action` en el contenedor principal.
- Requiere verificación manual final en iPad (solicitada al usuario).