### PR TITLE
Handle silent auth failure and stale sessions

### DIFF
--- a/src/lib/googleDrive.ts
+++ b/src/lib/googleDrive.ts
@@ -6,7 +6,7 @@ let gapiInited = false;
 let gisInited = false;
 
 export const googleDrive = {
-  async init(onAuthenticated: (token: string) => void) {
+  async init(onAuthenticated: (token: string) => void, onError?: (error: any) => void) {
     return new Promise<void>(async (resolve) => {
       // Wait for scripts to load
       const waitForGlobal = (key: string) => {
@@ -47,7 +47,9 @@ export const googleDrive = {
         scope: SCOPES,
         callback: (response: any) => {
           if (response.error !== undefined) {
-            throw response;
+            if (onError) onError(response);
+            else throw response;
+            return;
           }
           onAuthenticated(response.access_token);
         },

--- a/src/store/syncStore.ts
+++ b/src/store/syncStore.ts
@@ -69,6 +69,17 @@ export const useSyncStore = create<SyncState>((set, get) => ({
       const isRefreshing = !!localStorage.getItem('cuaderno-drive-token');
       localStorage.setItem('cuaderno-drive-token', token);
       await get().setupConnection(token, isRefreshing);
+    }, (error: any) => {
+      console.error('Google Auth Error:', error);
+      // If silent refresh fails (or any other auth error while we thought we were connected)
+      // we must clear the session to break the loop.
+      if (get().isConfigured) {
+        console.warn('Silent refresh failed or session expired.');
+        localStorage.removeItem('cuaderno-drive-token');
+        localStorage.removeItem('cuaderno-user-info');
+        set({ isConfigured: false, user: null });
+        toast.error('Session expired. Please log in again.');
+      }
     }).then(async () => {
       // Library is ready. Check if we have a stored token to restore session.
       const storedToken = localStorage.getItem('cuaderno-drive-token');


### PR DESCRIPTION
## Description
This PR addresses a critical synchronization issue where the application would enter an unrecoverable state when the Google Drive access token expired (e.g., after long inactivity or app suspension).

Previously, when a silent token refresh failed (returning an error like `interaction_required`), the error was unhandled in the `google-drive` library wrapper. This caused the application to mistakenly believe it was still "Configured", leading to an infinite loop of failed sync attempts and failed refresh requests.

Changes implemented:
- Updated `googleDrive.init` to accept an optional `onError` callback.
- Implemented the error handler in `syncStore` to catch authentication failures.
- If an auth error occurs while the app thinks it is configured, it now automatically clears the stale session data (`isConfigured: false`, removes tokens) and prompts the user to log in again via the UI.

## Type of Change
- [ ] Feature/Enhancement
- [x] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests

## Related Issue
Fixes #64

## Changelog Entry
Fixed an issue where synchronization would stop working after long periods of inactivity, requiring a manual logout/login to restore.

## Testing
- Verified that the project builds successfully.
- Logic verification:
    1. Log in to Google Drive sync.
    2. Simulate a token expiration (or wait for timeout).
    3. Trigger a sync or reload the page.
    4. Verify that the application correctly detects the auth failure, logs the user out locally, and allows re-authentication instead of silently failing in a loop.