### PR TITLE
Non-native confirmation dialog for logout and unsync

### DIFF
--- a/src/components/Settings/Settings.module.css
+++ b/src/components/Settings/Settings.module.css
@@ -208,6 +208,21 @@
   color: hsl(var(--color-text-secondary));
 }
 
+.modalToggle {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 8px 0;
+  cursor: pointer;
+}
+
+.modalToggleLabel {
+  flex: 1;
+  font-size: 0.9rem;
+  color: hsl(var(--color-text-primary));
+  line-height: 1.4;
+}
+
 .toggle {
   width: 34px;
   height: 18px;

--- a/src/components/UI/ConfirmationModal.module.css
+++ b/src/components/UI/ConfirmationModal.module.css
@@ -1,0 +1,99 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.modal {
+  background-color: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 90%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: hsl(var(--color-text-primary));
+}
+
+.description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: hsl(var(--color-text-secondary));
+  line-height: 1.5;
+}
+
+.description+.content {
+  margin-top: 0.5rem;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.actions button {
+  padding: 0.65rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.primary {
+  background-color: var(--color-accent);
+  color: white;
+}
+
+.primary:hover {
+  filter: brightness(1.1);
+}
+
+.danger {
+  background-color: hsl(var(--color-danger));
+  color: white;
+}
+
+.danger:hover {
+  filter: brightness(1.1);
+}
+
+.secondary {
+  background-color: transparent;
+  color: hsl(var(--color-text-secondary));
+  border: 1px solid hsl(var(--color-text-secondary) / 0.3) !important;
+}
+
+.secondary:hover {
+  background-color: hsl(var(--color-text-secondary) / 0.05);
+}
+
+[data-theme='dark'] .secondary:hover {
+  background-color: hsla(0, 0%, 100%, 0.05);
+}

--- a/src/components/UI/ConfirmationModal.tsx
+++ b/src/components/UI/ConfirmationModal.tsx
@@ -1,0 +1,65 @@
+import { useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './ConfirmationModal.module.css';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+interface ConfirmationModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'primary' | 'danger';
+  children?: React.ReactNode;
+}
+
+export const ConfirmationModal = ({
+  onConfirm,
+  onCancel,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  variant = 'primary',
+  children
+}: ConfirmationModalProps) => {
+  const { t } = useTranslation();
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onCancel]);
+
+  return createPortal(
+    <div className={styles.backdrop} onClick={onCancel}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <h3>{title}</h3>
+        {description && <p className={styles.description}>{description}</p>}
+
+        {children && <div className={styles.content}>{children}</div>}
+
+        <div className={styles.actions}>
+          <button className={styles.secondary} onClick={onCancel}>
+            {cancelLabel || t('cancel')}
+          </button>
+          <button
+            ref={confirmRef}
+            className={clsx(styles.primary, variant === 'danger' && styles.danger)}
+            onClick={onConfirm}
+          >
+            {confirmLabel || t('confirm')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "المجلد",
   "delete_confirm_notebook": "الدفتر",
   "delete": "حذف",
-  "confirm_logout_delete_data": "هل تريد حذف جميع البيانات المحفوظة في Google Drive قبل تسجيل الخروج؟",
+  "confirm_logout_delete_data": "حذف جميع البيانات المحفوظة في Google Drive قبل تسجيل الخروج",
   "privacy_policy": "الخصوصية وملفات تعريف الارتباط",
   "terms_of_service": "شروط الخدمة",
   "welcome_description": "Cuaderno هو تطبيق للدفاتر والرسم يركز على الخصوصية (محلي أولاً). تبقى بياناتك على جهازك ما لم تختر مزامنتها بشكل خاص مع حساب Google Drive الخاص بك.",
   "google_drive_privacy_notice": "من خلال الاتصال بـ Google Drive، تطبق Google سياسات الخصوصية وملفات تعريف الارتباط الخاصة بها.",
-  "learn_more": "تعرف على المزيد"
+  "learn_more": "تعرف على المزيد",
+  "label_font": "الخط",
+  "label_size": "الحجم",
+  "logout_confirmation_desc": "هل أنت متأكد أنك تريد تسجيل الخروج؟",
+  "unsync_confirm_title": "إيقاف المزامنة؟",
+  "unsync_confirm_desc": "هل أنت متأكد أنك تريد إيقاف المزامنة مع Google Drive؟"
 }

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "la carpeta",
   "delete_confirm_notebook": "el quadern",
   "delete": "Suprimir",
-  "confirm_logout_delete_data": "Voleu suprimir totes les dades guardades a Google Drive abans de tancar la sessió?",
+  "confirm_logout_delete_data": "Vull eliminar totes les dades guardades a Google Drive abans de tancar la sessió",
   "privacy_policy": "Privadesa i galetes",
   "terms_of_service": "Termes del servei",
   "welcome_description": "Cuaderno és una aplicació de notes i dibuix centrada en la privadesa (local-first). Les vostres dades es queden al vostre dispositiu llevat que trieu sincronitzar-les de forma privada amb el vostre compte de Google Drive.",
-  "google_drive_privacy_notice": "En connectar-vos a Google Drive, Google aplica les seves pròpies polítiques de privadesa i galetes.",
+  "google_drive_privacy_notice": "En connectar-vos a Google Drive, Google aplica les seves pròpies polítique de privadesa i galetes.",
   "learn_more": "Més informació",
   "label_font": "Tipografia",
-  "label_size": "Mida"
+  "label_size": "Mida",
+  "logout_confirmation_desc": "Estàs segur que vols tancar la sessió?",
+  "unsync_confirm_title": "Aturar sincronització?",
+  "unsync_confirm_desc": "Estàs segur que vols deixar de sincronitzar amb Google Drive?"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "den Ordner",
   "delete_confirm_notebook": "das Notizbuch",
   "delete": "Löschen",
-  "confirm_logout_delete_data": "Möchten Sie alle in Google Drive gespeicherten Daten löschen, bevor Sie sich abmelden?",
   "privacy_policy": "Datenschutz & Cookies",
   "terms_of_service": "Nutzungsbedingungen",
   "welcome_description": "Cuaderno ist eine datenschutzorientierte (local-first) Notizbuch- und Zeichenanwendung. Ihre Daten bleiben auf Ihrem Gerät, sofern Sie sie nicht privat mit Ihrem eigenen Google Drive-Konto synchronisieren.",
   "google_drive_privacy_notice": "Durch das Verbinden mit Google Drive wendet Google seine eigenen Datenschutz- und Cookie-Richtlinien an.",
   "learn_more": "Mehr erfahren",
   "label_font": "Typografie",
-  "label_size": "Größe"
+  "label_size": "Größe",
+  "confirm_logout_delete_data": "Alle gespeicherten Daten in Google Drive vor dem Abmelden löschen",
+  "logout_confirmation_desc": "Sind Sie sicher, dass Sie sich abmelden möchten?",
+  "unsync_confirm_title": "Synchronisierung stoppen?",
+  "unsync_confirm_desc": "Sind Sie sicher, dass Sie die Synchronisierung mit Google Drive stoppen möchten?"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "folder",
   "delete_confirm_notebook": "notebook",
   "delete": "Delete",
-  "confirm_logout_delete_data": "Do you want to delete all saved data in Google Drive before logging out?",
+  "confirm_logout_delete_data": "Delete all saved data in Google Drive before logging out",
   "privacy_policy": "Privacy & Cookies",
   "terms_of_service": "Terms of Service",
   "welcome_description": "Cuaderno is a privacy-focused (local-first) notebook and drawing application. Your data stays on your device unless you choose to sync it privately with your own Google Drive account.",
   "google_drive_privacy_notice": "By connecting to Google Drive, Google applies its own privacy and cookie policies.",
   "learn_more": "Learn more",
   "label_font": "Typography",
-  "label_size": "Size"
+  "label_size": "Size",
+  "logout_confirmation_desc": "Are you sure you want to log out?",
+  "unsync_confirm_title": "Stop Syncing?",
+  "unsync_confirm_desc": "Are you sure you want to stop syncing with Google Drive?"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "carpeta",
   "delete_confirm_notebook": "cuaderno",
   "delete": "Eliminar",
-  "confirm_logout_delete_data": "¿Quieres eliminar todos los datos guardados en Google Drive antes de cerrar sesión?",
+  "confirm_logout_delete_data": "Quiero eliminar todos los datos guardados en Google Drive antes de cerrar sesión",
   "privacy_policy": "Privacidad y Cookies",
   "terms_of_service": "Términos del Servicio",
   "welcome_description": "Cuaderno es una aplicación de notas y dibujos enfocada en la privacidad (local-first). Todos tus datos permanecen en tu dispositivo a menos que elijas sincronizarlos de forma privada con tu propia cuenta de Google Drive.",
   "google_drive_privacy_notice": "Al conectar Google Drive, Google aplica sus propias políticas de privacidad y cookies.",
   "learn_more": "Más información",
   "label_font": "Tipografía",
-  "label_size": "Tamaño"
+  "label_size": "Tamaño",
+  "logout_confirmation_desc": "¿Estás seguro de que quieres cerrar sesión?",
+  "unsync_confirm_title": "¿Detener sincronización?",
+  "unsync_confirm_desc": "¿Estás seguro de que quieres dejar de sincronizar con Google Drive?"
 }

--- a/src/locales/eu.json
+++ b/src/locales/eu.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "karpeta",
   "delete_confirm_notebook": "koadernoa",
   "delete": "Ezabatu",
-  "confirm_logout_delete_data": "Google Drive-n gordetako datu guztiak ezabatu nahi dituzu saioa itxi aurretik?",
+  "confirm_logout_delete_data": "Google Drive-n gordetako datu guztiak ezabatu nahi ditut saioa itxi aurretik",
   "privacy_policy": "Pribatutasuna eta Cookie-ak",
   "terms_of_service": "Zerbitzu-baldintzak",
   "welcome_description": "Cuaderno pribatutasunean zentratutako (local-first) koaderno eta marrazketa aplikazioa da. Zure datuak zure gailuan geratzen dira, zure Google Drive kontuarekin modu pribatuan sinkronizatzea aukeratzen ez baduzu.",
   "google_drive_privacy_notice": "Google Drive-ra konektatzean, Google-k bere pribatutasun eta cookie politikak aplikatzen ditu.",
   "learn_more": "Gehiago jakin",
   "label_font": "Tipografia",
-  "label_size": "Tamaina"
+  "label_size": "Tamaina",
+  "logout_confirmation_desc": "Ziur zaude saioa itxi nahi duzula?",
+  "unsync_confirm_title": "Sinkronizazioa gelditu?",
+  "unsync_confirm_desc": "Ziur zaude Google Driverekin sinkronizatzeari utzi nahi diozula?"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "le dossier",
   "delete_confirm_notebook": "le cahier",
   "delete": "Supprimer",
-  "confirm_logout_delete_data": "Voulez-vous supprimer toutes les données enregistrées dans Google Drive avant de vous déconnecter ?",
+  "confirm_logout_delete_data": "Supprimer toutes les données sauvegardées sur Google Drive avant de se déconnecter",
   "privacy_policy": "Confidentialité et Cookies",
   "terms_of_service": "Conditions d service",
   "welcome_description": "Cuaderno est une application de notes et de dessin axée sur la confidentialité (local-first). Vos données restent sur votre appareil, à moins que vous ne choisissiez de les synchroniser de manière privée avec votre compte Google Drive.",
   "google_drive_privacy_notice": "En vous connectant à Google Drive, Google applique ses propres politiques de confidentialité et de cookies.",
   "learn_more": "En savoir plus",
   "label_font": "Typographie",
-  "label_size": "Taille"
+  "label_size": "Taille",
+  "logout_confirmation_desc": "Êtes-vous sûr de vouloir vous déconnecter ?",
+  "unsync_confirm_title": "Arrêter la synchronisation ?",
+  "unsync_confirm_desc": "Êtes-vous sûr de vouloir arrêter la synchronisation avec Google Drive ?"
 }

--- a/src/locales/gl.json
+++ b/src/locales/gl.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "cartafol",
   "delete_confirm_notebook": "caderno",
   "delete": "Eliminar",
-  "confirm_logout_delete_data": "Queres eliminar todos os datos gardados en Google Drive antes de pechar a sesión?",
+  "confirm_logout_delete_data": "Quero eliminar todos os datos gardados en Google Drive antes de pechar a sesión",
   "privacy_policy": "Privacidade e Cookies",
   "terms_of_service": "Termos de Servizo",
   "welcome_description": "Cuaderno é unha aplicación de notas e debuxo centrada na privacidade (local-first). Os teus datos quedan no teu dispositivo a menos que elixas sincronizalos de xeito privado coa túa propia conta de Google Drive.",
   "google_drive_privacy_notice": "Ao conectarte a Google Drive, Google aplica as súas propias políticas de privacidade e cookies.",
   "learn_more": "Máis información",
   "label_font": "Tipografía",
-  "label_size": "Tamaño"
+  "label_size": "Tamaño",
+  "logout_confirmation_desc": "Estás seguro de que queres pechar a sesión?",
+  "unsync_confirm_title": "Deter a sincronización?",
+  "unsync_confirm_desc": "Estás seguro de que queres deixar de sincronizar con Google Drive?"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "cartella",
   "delete_confirm_notebook": "quaderno",
   "delete": "Elimina",
-  "confirm_logout_delete_data": "Vuoi eliminare tutti i dati salvati su Google Drive prima di disconnetterti?",
+  "confirm_logout_delete_data": "Elimina tutti i dati salvati su Google Drive prima di uscire",
   "privacy_policy": "Privacy e Cookie",
   "terms_of_service": "Termini di servizio",
   "welcome_description": "Cuaderno è un applicazione per note e disegni incentrata sulla privacy (local-first). I tuoi dati rimangono sul tuo dispositivo a meno che tu non scelga di sincronizzarli privatamente con il tuo account Google Drive.",
   "google_drive_privacy_notice": "Collegandoti a Google Drive, Google applica le proprie politiche sulla privacy e sui cookie.",
   "learn_more": "Scopri di più",
   "label_font": "Tipografia",
-  "label_size": "Dimensione"
+  "label_size": "Dimensione",
+  "logout_confirmation_desc": "Sei sicuro di voler uscire?",
+  "unsync_confirm_title": "Interrompere la sincronizzazione?",
+  "unsync_confirm_desc": "Sei sicuro di voler interrompere la sincronizzazione con Google Drive?"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "フォルダー",
   "delete_confirm_notebook": "ノートブック",
   "delete": "削除",
-  "confirm_logout_delete_data": "ログアウトする前に、Googleドライブに保存されているすべてのデータを削除しますか？",
+  "confirm_logout_delete_data": "ログアウトする前に Google ドライブに保存されているすべてのデータを削除する",
   "privacy_policy": "プライバシーとクッキー",
   "terms_of_service": "利用規約",
   "welcome_description": "Cuadernoはプライバシー重視（ローカルファースト）のノートおよび描画アプリケーションです。データはデバイスに残りますが、自分のGoogleドライブアカウントとプライベートに同期することも選択できます。",
   "google_drive_privacy_notice": "Googleドライブに接続すると、Google独自のプライバシーおよびクッキーポリシーが適用されます。",
-  "learn_more": "詳細はこちら"
+  "learn_more": "詳細はこちら",
+  "label_font": "フォント",
+  "label_size": "サイズ",
+  "logout_confirmation_desc": "本当にログアウトしますか？",
+  "unsync_confirm_title": "同期を停止しますか？",
+  "unsync_confirm_desc": "本当に Google ドライブとの同期を停止しますか？"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "폴더",
   "delete_confirm_notebook": "노트북",
   "delete": "삭제",
-  "confirm_logout_delete_data": "로그아웃하기 전에 Google 드라이브에 저장된 모든 데이터를 삭제하시겠습니까?",
+  "confirm_logout_delete_data": "로그아웃하기 전에 Google 드라이브에 저장된 모든 데이터 삭제",
   "privacy_policy": "개인정보 보호 및 쿠키",
   "terms_of_service": "서비스 약관",
   "welcome_description": "Cuaderno는 개인정보 보호 중심(local-first)의 노트 및 그리기 애플리케이션입니다. 데이터는 장치에 저장되며, 원하는 경우 Google 드라이브 계정과 비공개로 동기화할 수도 있습니다.",
   "google_drive_privacy_notice": "Google 드라이브에 연결하면 Google의 자체 개인정보 보호 및 쿠키 정책이 적용됩니다.",
-  "learn_more": "자세히 알아보기"
+  "learn_more": "자세히 알아보기",
+  "label_font": "글꼴",
+  "label_size": "크기",
+  "logout_confirmation_desc": "정말 로그아웃하시겠습니까?",
+  "unsync_confirm_title": "동기화를 중지하시겠습니까?",
+  "unsync_confirm_desc": "정말 Google 드라이브와의 동기화를 중지하시겠습니까?"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "map",
   "delete_confirm_notebook": "notitieblok",
   "delete": "Verwijderen",
-  "confirm_logout_delete_data": "Wilt u alle opgeslagen gegevens in Google Drive verwijderen voordat u uitlogt?",
+  "confirm_logout_delete_data": "Alle opgeslagen gegevens in Google Drive verwijderen voordat u uitlogt",
   "privacy_policy": "Privacy & Cookies",
   "terms_of_service": "Servicevoorwaarden",
   "welcome_description": "Cuaderno is een privacygerichte (local-first) notitie- en tekenapplicatie. Uw gegevens blijven op uw apparaat staan, tenzij u ervoor kiest om ze privé te synchroniseren met uw eigen Google Drive-account.",
   "google_drive_privacy_notice": "Door verbinding te maken met Google Drive, past Google zijn eigen privacy- en cookiebeleid toe.",
-  "learn_more": "Meer informatie"
+  "learn_more": "Meer informatie",
+  "label_font": "Typografie",
+  "label_size": "Grootte",
+  "logout_confirmation_desc": "Weet u zeker dat u wilt uitloggen?",
+  "unsync_confirm_title": "Stop met synchroniseren?",
+  "unsync_confirm_desc": "Weet u zeker dat u wilt stoppen met synchroniseren met Google Drive?"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "folder",
   "delete_confirm_notebook": "notatnik",
   "delete": "Usuń",
-  "confirm_logout_delete_data": "Czy chcesz usunąć wszystkie dane zapisane na Google Drive przed wylogowaniem?",
+  "confirm_logout_delete_data": "Usuń wszystkie zapisane dane w Google Drive przed wylogowaniem",
   "privacy_policy": "Prywatność i pliki cookie",
   "terms_of_service": "Warunki usługi",
   "welcome_description": "Cuaderno to aplikacja do notatek i rysowania kładąca nacisk na prywatność (local-first). Twoje dane pozostają na urządzeniu, chyba że zdecydujesz się na ich prywatną synchronizację z własnym kontem Google Drive.",
   "google_drive_privacy_notice": "Łącząc się z Google Drive, Google stosuje własne zasady prywatności i plików cookie.",
-  "learn_more": "Dowiedz się więcej"
+  "learn_more": "Dowiedz się więcej",
+  "label_font": "Typografia",
+  "label_size": "Rozmiar",
+  "logout_confirmation_desc": "Czy na pewno chcesz się wylogować?",
+  "unsync_confirm_title": "Zatrzymać synchronizację?",
+  "unsync_confirm_desc": "Czy na pewno chcesz zatrzymać synchronizację z Google Drive?"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -105,12 +105,15 @@
   "delete_confirm_folder": "pasta",
   "delete_confirm_notebook": "caderno",
   "delete": "Excluir",
-  "confirm_logout_delete_data": "Deseja excluir todos os dados salvos no Google Drive antes de sair?",
   "privacy_policy": "Privacidade e Cookies",
   "terms_of_service": "Termos de Serviço",
   "welcome_description": "Cuaderno é um aplicativo de notas e desenhos focado na privacidade (local-first). Seus dados permanecem no seu dispositivo, a menos que você escolha sincronizá-los privadamente com sua própria conta do Google Drive.",
   "google_drive_privacy_notice": "Ao conectar-se ao Google Drive, o Google aplica suas próprias políticas de privacidade e cookies.",
   "learn_more": "Saiba mais",
   "label_font": "Tipografia",
-  "label_size": "Tamanho"
+  "label_size": "Tamanho",
+  "confirm_logout_delete_data": "Excluir todos os dados salvos no Google Drive antes de sair",
+  "logout_confirmation_desc": "Tem certeza de que deseja sair?",
+  "unsync_confirm_title": "Parar a sincronização?",
+  "unsync_confirm_desc": "Tem certeza de que deseja parar a sincronização com o Google Drive?"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "папку",
   "delete_confirm_notebook": "блокнот",
   "delete": "Удалить",
-  "confirm_logout_delete_data": "Хотите удалить все данные на Google Диске перед выходом?",
+  "confirm_logout_delete_data": "Удалить все сохраненные данные в Google Drive перед выходом",
   "privacy_policy": "Конфиденциальность и Cookies",
   "terms_of_service": "Условия использования",
   "welcome_description": "Cuaderno — это приложение для заметок и рисования, ориентированное на конфиденциальность (local-first). Ваши данные остаются на устройстве, если вы не решите синхронизировать их со своим аккаунтом Google Диска.",
   "google_drive_privacy_notice": "При подключении к Google Диску применяются правила конфиденциальности и использования файлов cookie Google.",
-  "learn_more": "Узнать больше"
+  "learn_more": "Узнать больше",
+  "label_font": "Шрифт",
+  "label_size": "Размер",
+  "logout_confirmation_desc": "Вы уверены, что хотите выйти?",
+  "unsync_confirm_title": "Остановить синхронизацию?",
+  "unsync_confirm_desc": "Вы уверены, что хотите остановить синхронизацию с Google Drive?"
 }

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "mapp",
   "delete_confirm_notebook": "anteckningsbok",
   "delete": "Ta bort",
-  "confirm_logout_delete_data": "Vill du ta bort all sparad data på Google Drive innan du loggar ut?",
+  "confirm_logout_delete_data": "Ta bort all sparad data i Google Drive innan du loggar ut",
   "privacy_policy": "Integritet & Cookies",
   "terms_of_service": "Användarvillkor",
   "welcome_description": "Cuaderno är en integritetsfokuserad (local-first) antecknings- och ritapp. Din data stannar på din enhet om du inte väljer att synkronisera den privat med ditt eget Google Drive-konto.",
   "google_drive_privacy_notice": "Genom att ansluta till Google Drive tillämpar Google sina egna policyer för integritet och cookies.",
-  "learn_more": "Läs mer"
+  "learn_more": "Läs mer",
+  "label_font": "Typsnitt",
+  "label_size": "Storlek",
+  "logout_confirmation_desc": "Är du säker på att du vill logga ut?",
+  "unsync_confirm_title": "Stoppa synkronisering?",
+  "unsync_confirm_desc": "Är du säker på att du vill sluta synkronisera med Google Drive?"
 }

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "klasör",
   "delete_confirm_notebook": "not defteri",
   "delete": "Sil",
-  "confirm_logout_delete_data": "Çıkış yapmadan önce Google Drive'daki tüm verileri silmek istiyor musunuz?",
+  "confirm_logout_delete_data": "Oturumu kapatmadan önce Google Drive'daki tüm kayıtlı verileri sil",
   "privacy_policy": "Gizlilik ve Çerezler",
   "terms_of_service": "Hizmet Şartları",
   "welcome_description": "Cuaderno, gizlilik odaklı (yerel öncelikli) bir not defteri ve çizim uygulamasıdır. Siz Google Drive hesabınızla özel olarak senkronize etmeyi seçmediğiniz sürece verileriniz cihazınızda kalır.",
   "google_drive_privacy_notice": "Google Drive'a bağlanarak, Google kendi gizlilik ve çerez politikalarını uygular.",
-  "learn_more": "Daha fazla bilgi al"
+  "learn_more": "Daha fazla bilgi al",
+  "label_font": "Yazı Tipi",
+  "label_size": "Boyut",
+  "logout_confirmation_desc": "Oturumu kapatmak istediğinizden emin misiniz?",
+  "unsync_confirm_title": "Senkronizasyonu Durdur?",
+  "unsync_confirm_desc": "Google Drive ile senkronizasyonu durdurmak istediğinizden emin misiniz?"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -105,10 +105,15 @@
   "delete_confirm_folder": "文件夹",
   "delete_confirm_notebook": "笔记本",
   "delete": "删除",
-  "confirm_logout_delete_data": "您想在退出登录前删除 Google 云端硬盘中保存的所有数据吗？",
+  "confirm_logout_delete_data": "退出前删除 Google 云端硬盘中所有保存的数据",
   "privacy_policy": "隐私与 Cookie",
   "terms_of_service": "服务条款",
   "welcome_description": "Cuaderno 是一款专注于隐私（本地优先）的笔记本和绘图应用。除非您选择私下同步到自己的 Google 云端硬盘账户，否则您的数据将保留在您的设备上。",
   "google_drive_privacy_notice": "通过连接到 Google 云端硬盘，Google 将适用其自身的隐私和 Cookie 政策。",
-  "learn_more": "了解更多"
+  "learn_more": "了解更多",
+  "label_font": "字体",
+  "label_size": "大小",
+  "logout_confirmation_desc": "您确定要退出吗？",
+  "unsync_confirm_title": "停止同步？",
+  "unsync_confirm_desc": "您确定要停止与 Google 云端硬盘同步吗？"
 }


### PR DESCRIPTION
## Description
Replaced the native `window.confirm` dialog with a custom, non-native `ConfirmationModal` component. This new modal is used when logging out and when disabling auto-sync from the settings menu.

Key changes:
- Created a reusable `ConfirmationModal` component with glass-morphism styling.
- Integrated the modal into the `Settings` component.
- Added a "Delete all saved data in Google Drive" toggle inside the logout confirmation modal.
- Improved the layout and alignment of the modal components.
- Provided full translations for all 18 supported languages.
- Fixed several lint warnings in `Settings.tsx`.

## Type of Change
- [x] Feature/Enhancement
- [ ] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests

## Related Issue
Fixes #57

## Changelog Entry
Added a custom, non-native confirmation dialog for logout and disabling auto-sync, with full localization support for 18 languages and UI layout refinements.

## Testing
- Manually verified that clicking the logout button triggers the custom modal.
- Verified that the "Delete all saved data" toggle works as expected.
- Verified that disabling "Auto-sync" triggers the confirmation modal.
- Verified that "Cancel" correctly prevents the action and "Confirm" executes it.
- Tested UI layout across light and dark modes.
- Checked translations in Spanish, English, French, and other languages to ensure correctness and positive statement phrasing.
