### PR TITLE
fix(sync): manage login token expiration in background

### DIFF
--- a/src/lib/googleDrive.ts
+++ b/src/lib/googleDrive.ts
@@ -6,7 +6,7 @@ let gapiInited = false;
 let gisInited = false;
 
 export const googleDrive = {
-  async init(onAuthenticated: (token: string) => void, onError?: (error: any) => void) {
+  async init(onAuthenticated: (response: any) => void, onError?: (error: any) => void) {
     return new Promise<void>(async (resolve) => {
       // Wait for scripts to load
       const waitForGlobal = (key: string) => {
@@ -77,7 +77,7 @@ export const googleDrive = {
             else throw response;
             return;
           }
-          onAuthenticated(response.access_token);
+          onAuthenticated(response);
         },
       });
       gisInited = true;


### PR DESCRIPTION
## Description
This PR implements robust token expiration management to prevent users from being in a "falsely logged in" state after the app returns from the background. 

Key changes:
- Tracks `expiresAt` timestamp for the Google Drive token.
- Persists expiration info in `localStorage`.
- Added a `visibilitychange` listener in `App.tsx` that triggers a silent token refresh if the token is expired or close to expiring (within 5 minutes) when the tab becomes visible.
- Improved proactive refresh interval from 50 minutes to 10 minutes verification.

## Type of Change
- [x] Feature/Enhancement
- [x] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests

## Related Issue
Fixes #75

## Changelog Entry
Added robust background token expiration management and proactive refresh on app visibility change.

## Testing
- Verified `expiresAt` is correctly calculated and stored.
- Manually simulated token expiration by manipulating `localStorage` and verified that switching tabs triggers a successful silent refresh.
- Verified that periodic checks (every 10 min) also trigger refreshes if needed.