### PR TITLE
chore: enforce GitHub CLI usage for agents

### DIFF
--- a/.agent/workflows/development-flow.md
+++ b/.agent/workflows/development-flow.md
@@ -7,9 +7,11 @@ description: Development and Validation Rules
 
 This document establishes the mandatory rules for development in this repository.
 
-## 1. Branch Creation
+## 1. Branch Creation and Issue Management
+- **PREFERENCE**: Use the GitHub CLI (`gh`) for all interactions with issues and PRs.
 - All new feature or bug fix branches must start from `develop`.
 - Use `gh issue develop <ID>` to automate creation and linking.
+- Use `gh issue list` and `gh issue view <ID>` to stay updated on tasks.
 
 ## 2. Pull Request Process
 - Upon completing development, open a PR targeting `develop`.

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,13 @@
+# GitHub CLI Usage Rules
+
+All agents interacting with this repository MUST use the GitHub CLI (`gh`) for any tasks related to:
+- Reviewing Issues (`gh issue list`, `gh issue view`)
+- Managing Pull Requests (`gh pr list`, `gh pr view`, `gh pr checkout`, `gh pr create`)
+- Branch management linked to issues (`gh issue develop`)
+
+## Reference Workflows
+Specific step-by-step guides for common tasks can be found in:
+- [.agent/workflows/development-flow.md](file:///Users/johju/Documents/dev/cuaderno/.agent/workflows/development-flow.md)
+- [.agent/workflows/pr-creation.md](file:///Users/johju/Documents/dev/cuaderno/.agent/workflows/pr-creation.md)
+
+Always check these workflows before performing GitHub-related operations.

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.agent/*


### PR DESCRIPTION
## Description
This PR enforces the usage of the GitHub CLI (`gh`) for any Antigravity agent working on this repository. It introduces a `.cursorrules` file with clear instructions and updates the development flow documentation. It also ensures that the `.agent` directory (where instructions/workflows reside) is no longer ignored by Git.

## Type of Change
- [x] Internal/Chore
- [x] Documentation

## Related Issue
N/A

## Changelog Entry
Enforce GitHub CLI usage for agents and track `.agent` workflows in Git.

## Testing
- Verified `.cursorrules` content.
- Verified `.gitignore` update.
- Verified `development-flow.md` update.
