### PR TITLE
Refactor: Split monolithic CanvasArea into modular components and hooks

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -17,32 +17,6 @@ import { useUserPreferencesStore } from '../../store/userPreferencesStore';
 import { useFileSystemStore } from '../../store/fileSystemStore';
 import clsx from 'clsx';
 import { UIPortal } from '../UIPortal';
-
-import {
-  Bold,
-  Italic,
-  Underline,
-  Strikethrough,
-  Link as LinkIcon,
-  Square,
-  Circle,
-  Triangle,
-  Diamond,
-  ArrowBigUp,
-  ArrowBigDown,
-  ArrowBigLeft,
-  ArrowBigRight,
-  Minus,
-  Star,
-  Hexagon,
-  Cloud,
-  Heart,
-  Pentagon,
-  Octagon,
-  X,
-  Check,
-  Shapes,
-} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { LinkInputModal } from '../UI/LinkInputModal';
 import {
@@ -51,115 +25,20 @@ import {
   StrokeOpacityStyle,
 } from '../../styles/customStyles';
 
-// Generic Scribble SVG
-const Scribble = ({ strokeWidth, color = 'currentColor' }: { strokeWidth: number, color?: string }) => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M4 14c2-4 5-6 8-2s6 2 8 0" />
-  </svg>
-);
-
-const TrapezoidIcon = ({ size = 16 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M6 5h8l4 10H2L6 5z" />
-  </svg>
-);
-
-const useDraggableWithBounds = (initialPosition: { x: number, y: number }, width: number, height: number) => {
-  const [position, setPosition] = useState(initialPosition);
-  const [isDraggingState, setIsDraggingState] = useState(false);
-  const isDragging = useRef(false);
-  const hasMoved = useRef(false); // Track if significant movement occurred
-  const startPos = useRef({ x: 0, y: 0 });
-  const itemStartPos = useRef({ x: 0, y: 0 });
-
-  const clamp = (val: number, min: number, max: number) => Math.min(Math.max(val, min), max);
-
-  const handlePointerDown = (e: React.PointerEvent) => {
-    hasMoved.current = false;
-    // Only left click for mouse; all pointer types for touch/pen
-    if (e.pointerType === 'mouse' && e.button !== 0) return;
-
-    // Don't drag if the event comes from the opacity slider or other range inputs
-    const target = e.target as HTMLElement;
-    if (target.classList.contains('opacitySlider') ||
-      target.closest('.opacityRow') ||
-      (target instanceof HTMLInputElement && target.type === 'range')) {
-      return;
-    }
-
-    // e.preventDefault(); // Don't prevent default on pointerdown or clicks might break
-    isDragging.current = true;
-    setIsDraggingState(true);
-    hasMoved.current = false;
-    startPos.current = { x: e.clientX, y: e.clientY };
-    itemStartPos.current = position;
-
-    document.addEventListener('pointermove', handlePointerMove);
-    document.addEventListener('pointerup', handlePointerUp);
-
-    // Capture the pointer to ensure we get events even if it leaves the element
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  };
-
-  const handlePointerMove = (e: PointerEvent) => {
-    if (!isDragging.current) return;
-
-    const dx = e.clientX - startPos.current.x;
-    const dy = e.clientY - startPos.current.y;
-
-    // Threshold for "drag vs click": Increased to 10px to avoid accidental nudges
-    if (!hasMoved.current && (Math.abs(dx) > 10 || Math.abs(dy) > 10)) {
-      hasMoved.current = true;
-    }
-
-    // Only update position IF we have moved beyond the threshold
-    if (hasMoved.current) {
-      const newX = clamp(itemStartPos.current.x + dx, 0, window.innerWidth - width);
-      const newY = clamp(itemStartPos.current.y + dy, 0, window.innerHeight - height);
-      setPosition({ x: newX, y: newY });
-    }
-  };
-
-  const handlePointerUp = (e: PointerEvent) => {
-    isDragging.current = false;
-    setIsDraggingState(false);
-    document.removeEventListener('pointermove', handlePointerMove);
-    document.removeEventListener('pointerup', handlePointerUp);
-
-    try {
-      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-    } catch {
-      // Ignore if already released or invalid
-    }
-  };
-
-  // Adjust position on resize OR dimension change (e.g. collapse/expand) to keep it in bounds
-  useEffect(() => {
-    setPosition(p => ({
-      x: clamp(p.x, 0, window.innerWidth - width),
-      y: clamp(p.y, 0, window.innerHeight - height)
-    }));
-  }, [width, height]);
-
-  // Window resize separate listener
-  useEffect(() => {
-    const handleResize = () => {
-      setPosition(p => ({
-        x: clamp(p.x, 0, window.innerWidth - width),
-        y: clamp(p.y, 0, window.innerHeight - height)
-      }));
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [width, height]);
-
-  return { position, setPosition, handlePointerDown, hasMoved, isDragging: isDraggingState };
-};
+// Extracted modules
+import { useDraggableWithBounds } from '../../hooks/useDraggableWithBounds';
+import { applyStyleToRichText, fontFamilies, fontSizes } from './utils';
+import {
+  BubbleCollapsed,
+  BubbleTextSection,
+  BubbleShapeSection,
+  BubbleStrokeSection,
+  BubbleFillSection,
+} from './sections';
 
 interface BubbleProps {
   activeTool: string;
 }
-
 
 export const Bubble = track(({ activeTool }: BubbleProps) => {
   const { t } = useTranslation();
@@ -167,7 +46,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
   const isDarkMode = useIsDarkMode();
   const theme = getDefaultColorTheme({ isDarkMode });
   const [isCollapsed, setIsCollapsed] = useState(false);
-  // No longer using Dropdown states for text settings
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [relativeClickPoint, setRelativeClickPoint] = useState({ x: 0, y: 0 });
   const savedRange = useRef<Range | null>(null);
@@ -194,7 +72,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     if (shapeEl) {
       (shapeEl as HTMLElement).focus();
 
-      // Ensure we hit the next frame for focus and range to be fully restored
       setTimeout(() => {
         const selection = window.getSelection();
         if (savedRange.current && selection) {
@@ -204,10 +81,8 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
 
         const currentSelection = window.getSelection();
         if (currentSelection && currentSelection.isCollapsed) {
-          // If no selection, insert the URL as the link text
           document.execCommand('insertHTML', false, `<a href="${url}">${url}</a>`);
         } else {
-          // If there is a selection, wrap it in a link
           document.execCommand('createLink', false, url);
         }
         setIsLinkModalOpen(false);
@@ -275,7 +150,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     if (!isRichText) return;
 
     const updateStats = (e?: Event) => {
-      // If we are typing, don't sync from DOM unless it's a specific navigation key
       if (e?.type === 'keydown') {
         const key = (e as KeyboardEvent).key;
         const navKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'];
@@ -360,7 +234,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
           })()
         };
 
-        // Sync back to global "saved configuration"
         userPrefs.updatePreferences({
           textBold: next.bold,
           textItalic: next.italic,
@@ -376,7 +249,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
       });
     };
 
-    // Priming for NEW shapes
     const html = (editingShape?.props as any)?.html || '';
     const isNewNode = html === '' || html === '<div></div>' || html === `<div>${t('start_typing')}</div>` || html === t('start_typing');
 
@@ -392,16 +264,8 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         document.execCommand('styleWithCSS', false, 'true');
         document.execCommand('foreColor', false, hex);
 
-        const fonts: Record<string, string> = {
-          draw: '"Comic Sans MS", "Chalkboard SE", "Comic Neue", sans-serif',
-          sans: 'Inter, sans-serif',
-          serif: 'serif',
-          mono: 'monospace'
-        };
-        document.execCommand('fontName', false, fonts[userPrefs.textFont] || 'sans-serif');
-
-        const sizes: Record<string, string> = { xs: '3', s: '4', m: '5', l: '6', xl: '7', xxl: '7' };
-        document.execCommand('fontSize', false, sizes[userPrefs.textSize] || '4');
+        document.execCommand('fontName', false, fontFamilies[userPrefs.textFont] || 'sans-serif');
+        document.execCommand('fontSize', false, fontSizes[userPrefs.textSize] || '4');
 
         setRichStats({
           bold: userPrefs.textBold,
@@ -421,7 +285,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     if (isNewNode) {
       requestAnimationFrame(applyPersistentStyles);
     } else {
-      // For existing shapes, sync once on focus and then on events
       requestAnimationFrame(() => updateStats());
       document.addEventListener('pointerup', updateStats);
       document.addEventListener('keyup', updateStats);
@@ -433,35 +296,30 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     };
   }, [editor, t, colorsMap, userPrefs]);
 
-  // 💡 PROACTIVE SYNC: When switching to text tool, push current persistent stats to Tldraw context
-  // This ensures new shapes inherit the correct color/size from the very first frame.
+  // Proactive sync when switching to text tool
   useEffect(() => {
     if (activeTool === 'text') {
       editor.setStyleForNextShapes(DefaultColorStyle, richStats.color);
       editor.setStyleForNextShapes(DefaultSizeStyle, richStats.size);
       editor.setStyleForNextShapes(DefaultFontStyle, richStats.font);
-
-      // VALIDATION FIX: Sanitize 'justify' for Tldraw default style context
       const validAlign = richStats.align === 'justify' ? 'start' : richStats.align;
       editor.setStyleForNextShapes(DefaultTextAlignStyle, validAlign);
     }
   }, [activeTool, editor, richStats.color, richStats.size, richStats.font, richStats.align]);
 
-  // 💡 SYNC FROM SELECTION: When selecting text objects, sync bubble stats from the first one
+  // Sync from selection
   useEffect(() => {
     if (isSelectTool && isAllText && selectedShapes[0]) {
       const first = selectedShapes[0] as any;
       const html = first.props.html || '';
-
-      // Heuristic to detect if style is active in HTML (since we force global prop to false for these)
       const hasStrike = html.includes('line-through') || html.includes('<s>') || html.includes('<strike>') || html.includes('<del>');
       const hasUnderline = html.includes('underline') || html.includes('<u>');
 
       setRichStats({
         bold: first.props.bold || false,
         italic: first.props.italic || false,
-        underline: first.props.underline || hasUnderline, // Trust prop OR html
-        strike: first.props.strike || hasStrike,           // Trust prop OR html
+        underline: first.props.underline || hasUnderline,
+        strike: first.props.strike || hasStrike,
         font: first.props.font || 'draw',
         size: first.props.size || 'm',
         color: first.props.color || 'black',
@@ -476,7 +334,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     const editingShape = editingId ? editor.getShape(editingId) : null;
 
     if (editingShape?.type === 'rich-text') {
-      // Focus Restoration: If focus is lost to the button, restore it to the editor
       const active = document.activeElement;
       if (!active?.classList.contains('rich-text-container') && !active?.closest('.rich-text-container')) {
         const shapeEl = document.getElementById(editingShape.id)?.querySelector('.rich-text-container');
@@ -487,7 +344,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
 
       document.execCommand(command);
 
-      // Only update the shape props if the shape is empty.
       const isNewNode = (editingShape.props as any).html === '' || (editingShape.props as any).html === '<div></div>';
       if (isNewNode) {
         const currentVal = (editingShape.props as any)[key];
@@ -498,7 +354,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         });
       }
 
-      // Force sync stats and store
       setRichStats(prev => {
         const next = { ...prev, [key]: !prev[key as keyof typeof prev] };
         const storeKey = `text${key.charAt(0).toUpperCase() + key.slice(1)}` as keyof typeof userPrefs;
@@ -506,7 +361,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         return next;
       });
     } else {
-      // 💡 SELECTION MODE: Apply property to all selected text shapes
       if (selectedShapes.length > 0) {
         const textUpdates = selectedShapes
           .filter(s => s.type === 'rich-text')
@@ -514,7 +368,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
             const propValue = (s.props as any)[key];
             let isActive = propValue;
 
-            // For decorators, check HTML too because we might have forced prop to false
             if (key === 'strike') {
               const html = (s.props as any).html || '';
               isActive = propValue || html.includes('line-through') || html.includes('<s>') || html.includes('<strike>') || html.includes('<del>');
@@ -524,9 +377,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
             }
 
             const newValue = !isActive;
-
-            // Prevent double rendering: For strike/underline, ALWAYS set global prop to false
-            // The visual style is handled by the HTML content update
             const newPropValue = (key === 'strike' || key === 'underline') ? false : newValue;
 
             return {
@@ -534,7 +384,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
               type: 'rich-text',
               props: {
                 [key]: newPropValue,
-                // Unified HTML: Apply or remove style based on new value
                 html: applyStyleToRichText((s.props as any).html, key, newValue)
               }
             };
@@ -545,9 +394,7 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         }
       }
 
-      // Sync local state and store
       setRichStats(prev => {
-        // Toggle the UI state based on the assumption that we successfully toggled it
         const next = { ...prev, [key]: !prev[key as keyof typeof prev] };
         const storeKey = `text${key.charAt(0).toUpperCase() + key.slice(1)}` as keyof typeof userPrefs;
         userPrefs.updatePreferences({ [storeKey]: next[key as keyof typeof next] });
@@ -556,10 +403,8 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     }
   };
 
-  // Dimensions depend on state
-  // Match CSS width: 340px for expanded, 48px for collapsed
+  // Dimensions
   const width = isCollapsed ? 48 : 340;
-  // Increase height for shapes tool (has options)
   const height = isCollapsed ? 48 : (activeTool === 'text' ? 240 : (activeTool === 'shapes' ? 300 : 170));
 
   const { dominantHand } = useFileSystemStore();
@@ -567,19 +412,16 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
   const initialX = leftHandedMode ? 100 : window.innerWidth / 2 - 170;
   const { position, setPosition, handlePointerDown, hasMoved, isDragging } = useDraggableWithBounds({ x: initialX, y: 100 }, width, height);
 
-  // Custom "Smart Double Click" handler
+  // Smart double click handler
   const lastClickTime = useRef(0);
   const handleSmartClick = (e: React.MouseEvent) => {
     if (hasMoved.current) return;
     const now = Date.now();
-    // If click interval < 300ms, treat as double click
     if (now - lastClickTime.current < 300) {
-      // Store relative click point
       setRelativeClickPoint({
         x: e.clientX - position.x,
         y: e.clientY - position.y
       });
-      // Collapse to click position (centered)
       const newX = e.clientX - 24;
       const newY = e.clientY - 24;
       setPosition({ x: newX, y: newY });
@@ -590,7 +432,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
 
   const handleExpandCheck = () => {
     if (!hasMoved.current) {
-      // Expand from current position (centered bubble) to relative point
       const newX = (position.x + 24) - relativeClickPoint.x;
       const newY = (position.y + 24) - relativeClickPoint.y;
       setPosition({ x: newX, y: newY });
@@ -600,130 +441,15 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
 
   const colors = Object.keys(colorsMap);
 
-  // Size mapping to numbers for the SVG stroke width
-  const sizeMap: Record<string, number> = {
-    xs: 1,
-    s: 1.5,
-    m: 2.5,
-    l: 4,
-    xl: 6,
-    xxl: 10,
-  };
-
-  /**
-   * Applies a style strictly to all elements within the rich-text content,
-   * preserving structure but enforcing the new property value on every node.
-   * This replaces the old "unify" behavior which stripped styles and wrapped globally.
-   */
-  const applyStyleToRichText = (html: string, prop: string, value: any): string => {
-    if (!html) return html;
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = html;
-
-    const elements = Array.from(tempDiv.querySelectorAll('*'));
-    // Also include the root if it's not empty (though querySelectorAll('*') gets children)
-    // Tldraw rich text is usually <div>...</div>. The tempDiv wraps it.
-    // If the content is just text, it might be directly in tempDiv.
-    // However, usually we want to target the tags.
-
-    if (elements.length === 0 && tempDiv.textContent?.trim()) {
-      // If pure text, wrap it so we can style it
-      const wrapper = document.createElement('span');
-      while (tempDiv.firstChild) {
-        wrapper.appendChild(tempDiv.firstChild);
-      }
-      tempDiv.appendChild(wrapper);
-      elements.push(wrapper);
-    }
-
-    elements.forEach((el) => {
-      const htmlEl = el as HTMLElement;
-
-      if (prop === 'color') {
-        htmlEl.style.color = value;
-      }
-      if (prop === 'font') {
-        const fonts: Record<string, string> = {
-          draw: '"Comic Sans MS", "Chalkboard SE", "Comic Neue", sans-serif',
-          sans: 'Inter, sans-serif',
-          serif: 'serif',
-          mono: 'monospace'
-        };
-        htmlEl.style.fontFamily = fonts[value] || 'sans-serif';
-      }
-      if (prop === 'size') htmlEl.style.fontSize = '';
-
-      if (prop === 'size') htmlEl.style.fontSize = '';
-      if (prop === 'font') htmlEl.style.fontFamily = '';
-      if (prop === 'align') htmlEl.style.textAlign = '';
-
-      // Toggles
-      if (prop === 'bold') {
-        if (value) {
-          htmlEl.style.fontWeight = 'bold';
-        } else {
-          htmlEl.style.fontWeight = 'normal';
-          if (htmlEl.tagName === 'B' || htmlEl.tagName === 'STRONG') {
-            htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
-          }
-        }
-      }
-      if (prop === 'italic') {
-        if (value) {
-          htmlEl.style.fontStyle = 'italic';
-        } else {
-          htmlEl.style.fontStyle = 'normal';
-          if (htmlEl.tagName === 'I' || htmlEl.tagName === 'EM') {
-            htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
-          }
-        }
-      }
-      if (prop === 'underline') {
-        const current = htmlEl.style.textDecoration;
-        let parts = current.split(' ').map(s => s.trim()).filter(Boolean);
-        if (value) {
-          if (!parts.includes('underline')) parts.push('underline');
-        } else {
-          parts = parts.filter(p => p !== 'underline');
-          if (htmlEl.tagName === 'U') {
-            htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
-            return; // Element is gone, stop processing it
-          }
-        }
-        htmlEl.style.textDecoration = parts.join(' ');
-      }
-      if (prop === 'strike') {
-        const current = htmlEl.style.textDecoration;
-        let parts = current.split(' ').map(s => s.trim()).filter(Boolean);
-        if (value) {
-          // 'line-through' is standard
-          if (!parts.includes('line-through')) parts.push('line-through');
-        } else {
-          parts = parts.filter(p => p !== 'line-through');
-          if (htmlEl.tagName === 'S' || htmlEl.tagName === 'STRIKE' || htmlEl.tagName === 'DEL') {
-            htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
-            return; // Element is gone
-          }
-        }
-        htmlEl.style.textDecoration = parts.join(' ');
-      }
-    });
-
-    return tempDiv.innerHTML;
-  };
-
   // Helper to set style
   const setStyle = (style: any, value: any) => {
-    // 1. If editing a shape, update THAT shape's style
     const editingShapeId = editor.getEditingShapeId();
     if (editingShapeId) {
       const shape = editor.getShape(editingShapeId);
 
-      // Rich Text Logic
       if (shape && shape.type === 'rich-text') {
         if (style.id === 'tldraw:color') {
           const hex = colorsMap[value] || '#000000';
-          // Focus check
           const active = document.activeElement;
           if (!active?.classList.contains('rich-text-container')) {
             const shapeEl = document.getElementById(editingShapeId)?.querySelector('.rich-text-container');
@@ -733,30 +459,19 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
           document.execCommand('styleWithCSS', false, 'true');
           document.execCommand('foreColor', false, hex);
           setRichStats(prev => ({ ...prev, color: value }));
-
-          // If no selection, we should also update Tldraw's next shape style context
-          // as the primary fallback since the browser's insertion style might get lost
           editor.setStyleForNextShapes(DefaultColorStyle, value);
-          // Sync to Zustand global store
           userPrefs.updatePreferences({ textColor: value });
         }
 
         if (style.id === 'tldraw:font') {
-          const fonts: Record<string, string> = {
-            draw: '"Comic Sans MS", "Chalkboard SE", "Comic Neue", sans-serif',
-            sans: 'Inter, sans-serif',
-            serif: 'serif',
-            mono: 'monospace'
-          };
-          document.execCommand('fontName', false, fonts[value] || 'sans-serif');
+          document.execCommand('fontName', false, fontFamilies[value] || 'sans-serif');
           setRichStats(prev => ({ ...prev, font: value }));
           editor.setStyleForNextShapes(DefaultFontStyle, value);
           userPrefs.updatePreferences({ textFont: value });
         }
 
         if (style.id === 'tldraw:size') {
-          const sizes: Record<string, string> = { xs: '3', s: '4', m: '5', l: '6', xl: '7', xxl: '7' };
-          document.execCommand('fontSize', false, sizes[value] || '5');
+          document.execCommand('fontSize', false, fontSizes[value] || '5');
           setRichStats(prev => ({ ...prev, size: value }));
           editor.setStyleForNextShapes(DefaultSizeStyle, value);
           userPrefs.updatePreferences({ textSize: value });
@@ -764,18 +479,11 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
 
         if (style.id === 'tldraw:textAlign') {
           setRichStats(prev => ({ ...prev, align: value }));
-          // No execCommand for alignment -> Treat as Global Shape Prop
-          // Note: Alignment updates the whole shape via the updateShape below
         }
       }
 
-      // Map style ID to prop key
       const propKey = style.id.replace('tldraw:', '');
       const finalPropKey = propKey === 'textAlign' ? 'align' : propKey;
-
-      // Only update shape props if:
-      // 1. It's an alignment change (always global)
-      // 2. The shape is empty (save defaults)
       const isAlignment = finalPropKey === 'align';
       const isNewNode = shape && ((shape.props as any).html === '' || (shape.props as any).html === '<div></div>');
 
@@ -786,7 +494,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
           props: { [finalPropKey]: value }
         } as any);
       } else {
-        // Just update next shape style context for Tldraw
         if ('setStyleForNextShapes' in editor) {
           editor.setStyleForNextShapes(style, value);
         }
@@ -794,13 +501,11 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
       return;
     }
 
-    // 2. Set for currently selected shapes
     if (editor.getSelectedShapes().length > 0) {
       const selected = editor.getSelectedShapes();
       const propKey = style.id.replace('tldraw:', '');
       const finalPropKey = propKey === 'textAlign' ? 'align' : propKey;
 
-      // 💡 DEEP UNIFICATION: For rich-text shapes, unify internal HTML when property changes
       const textUpdates = selected
         .filter(s => s.type === 'rich-text')
         .map(s => ({
@@ -816,33 +521,25 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         editor.updateShapes(textUpdates as any);
       }
 
-      // VALIDATION FIX: Manual update for 'justify' to avoid schema validation error
       if (style.id === 'tldraw:textAlign' && value === 'justify') {
-        // Already handled in textUpdates above for rich-text
+        // Already handled in textUpdates
       } else {
         editor.setStyleForSelectedShapes(style, value);
       }
     }
-    // 3. Set for future shapes (context)
+
     if ('setStyleForNextShapes' in editor) {
-      // VALIDATION FIX: 'justify' is not a valid value for Tldraw's DefaultTextAlignStyle (start, middle, end)
-      // We only pass it to the editor context if it matches the schema.
-      // For 'justify', we rely on our custom store (useUserPreferencesStore) which injects it into props.
       if (style.id === 'tldraw:textAlign' && value === 'justify') {
-        // Do not update Tldraw's default style context for justify
-        // or fallback to start
         (editor as any).setStyleForNextShapes(style, 'start');
       } else {
         (editor as any).setStyleForNextShapes(style, value);
       }
     }
 
-    // 4. Update richStats for immediate UI feedback (Pending Styles)
     const propKey = style.id.replace('tldraw:', '');
     const finalPropKey = propKey === 'textAlign' ? 'align' : propKey;
     setRichStats(prev => ({ ...prev, [finalPropKey]: value }));
 
-    // Persist to store
     const prefUpdate: any = {};
     if (style.id === DefaultColorStyle.id) {
       prefUpdate.textColor = value;
@@ -870,16 +567,13 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     userPrefs.updatePreferences(prefUpdate);
   };
 
-  // 1. Draw/Shape Tools
-  // 2. Text Tool
-  // 3. Selection Tool IF we are editing Rich Text OR if we have selected shapes
+  // Early returns for visibility
   if (!isShapeTool && !isTextTool && !(isSelectTool && (isEditingRichText || hasSelectedShapes))) {
     return null;
   }
 
-  // Reactive reads (tracked)
+  // Reactive reads
   const getStyle = (style: any, fallback: string) => {
-    // 1. Check Editing Shape
     const editingShapeId = editor.getEditingShapeId();
     if (editingShapeId) {
       const shape = editor.getShape(editingShapeId);
@@ -892,7 +586,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
       }
     }
 
-    // 2. Check first selected shape (Requirement: initial config is from the first in selection)
     const firstShape = selectedShapes[0];
     if (firstShape && (firstShape as any).props) {
       const propKey = style.id.replace('tldraw:', '');
@@ -902,30 +595,24 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
       }
     }
 
-    // 3. Fallback to shared styles (for editor context/future shapes)
     const sharedStyles = editor.getSharedStyles();
     const shared = sharedStyles.get(style);
     if (shared && shared.type === 'shared') {
       return shared.value;
     }
-    // 4. Check next shape style (tool state)
     if ('getStyleForNextShape' in editor) {
       return (editor as any).getStyleForNextShape(style);
     }
     return fallback;
   };
 
-  // Visibility flags based on state and selection
-  // Visibility flags based on state and selection
+  // Visibility flags
   const isTextMode = isTextTool || isEditingRichText || (isSelectTool && isAllText);
-
-  // Specific visibility for sections
   const showTextSection = isTextMode;
   const showShapeTypeSection = (activeTool === 'geo' || activeTool === 'line' || activeTool === 'arrow' || activeTool === 'shapes') || (isSelectTool && isAllShape);
   const showStrokeSection = (activeTool === 'draw' || showShapeTypeSection) || (isSelectTool && (isAllShape || isAllDraw));
   const showFillSection = showShapeTypeSection;
 
-  // Hide bubble if mixed selection or nothing relevant
   if (isSelectTool && !isAllText && !isAllShape && !isAllDraw && !isAllImage && !isEditingRichText) {
     return null;
   }
@@ -939,7 +626,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
   const currentFill = (getStyle(DefaultFillStyle, 'none') as string);
   const currentTldrawTool = editor.getCurrentToolId();
 
-  // Get current values for custom styles
   const currentFillColor = (getStyle(FillColorStyle, 'black') as string);
   const currentFillOpacity = parseFloat(getStyle(FillOpacityStyle, '1') as string);
   const currentStrokeOpacity = parseFloat(getStyle(StrokeOpacityStyle, '1') as string);
@@ -952,51 +638,24 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
     return currentGeo;
   })();
 
-
   if (isCollapsed) {
     return (
       <UIPortal>
-        <div
-          className={clsx(styles.bubble, styles.collapsed, isDragging && styles.dragging)}
-          style={{
-            left: position.x,
-            top: position.y,
-            backgroundColor: 'var(--glass-bg)',
-            pointerEvents: 'auto'
-          }}
-          onPointerDown={(e) => { e.stopPropagation(); handlePointerDown(e); }}
-          onClick={handleExpandCheck}
-          data-is-ui="true"
-        >
-          {(activeTool === 'text' || isEditingRichText || (isSelectTool && isAllText)) ? (
-            <div style={{
-              fontFamily: (() => {
-                const fonts: Record<string, string> = {
-                  draw: '"Comic Sans MS", "Chalkboard SE", "Comic Neue", sans-serif',
-                  sans: 'Inter, sans-serif',
-                  serif: 'serif',
-                  mono: 'monospace'
-                };
-                return fonts[currentFont] || fonts.sans;
-              })(),
-              color: activeColorHex,
-              fontSize: '24px',
-              fontWeight: richStats.bold ? 'bold' : 'normal',
-              fontStyle: richStats.italic ? 'italic' : 'normal',
-              textDecoration: [
-                richStats.underline ? 'underline' : '',
-                richStats.strike ? 'line-through' : ''
-              ].filter(Boolean).join(' ') || 'none',
-              pointerEvents: 'none'
-            }}>
-              A
-            </div>
-          ) : (activeTool === 'geo' || activeTool === 'arrow' || activeTool === 'line' || activeTool === 'shapes' || (isSelectTool && isAllShape)) ? (
-            <Shapes size={24} />
-          ) : (
-            <Scribble strokeWidth={sizeMap[currentSize] || 2.5} color={activeColorHex} />
-          )}
-        </div>
+        <BubbleCollapsed
+          activeTool={activeTool}
+          isEditingRichText={isEditingRichText}
+          isSelectTool={isSelectTool}
+          isAllText={isAllText}
+          isAllShape={isAllShape}
+          currentFont={currentFont}
+          currentSize={currentSize}
+          activeColorHex={activeColorHex}
+          richStats={richStats}
+          isDragging={isDragging}
+          position={position}
+          handlePointerDown={handlePointerDown}
+          handleExpandCheck={handleExpandCheck}
+        />
       </UIPortal>
     );
   }
@@ -1011,427 +670,60 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
         data-is-ui="true"
       >
         {showTextSection && (
-          <div className={styles.textSettings}>
-            <div className={styles.topRow}>
-              <div className={styles.textToolsRow}>
-                {['draw', 'sans', 'serif', 'mono'].map(f => (
-                  <button
-                    key={f}
-                    className={clsx(styles.iconBtnTiny, currentFont === f && styles.active)}
-                    style={{
-                      fontFamily: `var(--font-${f})`,
-                      fontSize: '16px',
-                      fontWeight: 'bold',
-                    }}
-                    onClick={() => setStyle(DefaultFontStyle, f)}
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    title={t(`font_${f}`)}
-                  >
-                    A
-                  </button>
-                ))}
-                <div className={styles.verticalDivider} />
-                {['xs', 's', 'm', 'l', 'xl', 'xxl'].map(s => (
-                  <button
-                    key={s}
-                    className={clsx(styles.iconBtnTiny, currentSize === s && styles.active)}
-                    style={{
-                      fontSize: s === 'xs' ? '10px' :
-                        s === 's' ? '12px' :
-                          s === 'm' ? '14px' :
-                            s === 'l' ? '18px' :
-                              s === 'xl' ? '22px' : '26px',
-                      fontWeight: 'bold',
-                    }}
-                    onClick={() => setStyle(DefaultSizeStyle, s)}
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    title={t(`font_size_${s}`)}
-                  >
-                    A
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className={styles.toolsRow}>
-              <div className={styles.styleGroup}>
-                <button
-                  className={clsx(styles.iconBtn, richStats.bold && styles.active)}
-                  onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('bold'); }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  title={t('format_bold')}
-                >
-                  <Bold strokeWidth={2.5} size={16} />
-                </button>
-                <button
-                  className={clsx(styles.iconBtn, richStats.italic && styles.active)}
-                  onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('italic'); }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  title={t('format_italic')}
-                >
-                  <Italic strokeWidth={2.5} size={16} />
-                </button>
-                <button
-                  className={clsx(styles.iconBtn, richStats.underline && styles.active)}
-                  onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('underline'); }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  title={t('format_underline')}
-                >
-                  <Underline strokeWidth={2.5} size={16} />
-                </button>
-                <button
-                  className={clsx(styles.iconBtn, richStats.strike && styles.active)}
-                  onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('strikethrough'); }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  title={t('format_strikethrough')}
-                >
-                  <Strikethrough strokeWidth={2.5} size={16} />
-                </button>
-                <div className={styles.verticalDivider} />
-                <button
-                  className={styles.iconBtn}
-                  onClick={openLinkModal}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  title={t('format_link')}
-                >
-                  <LinkIcon size={16} />
-                </button>
-                <div className={styles.verticalDivider} />
-              </div>
-              <div className={styles.styleGroup}>
-                {['start', 'middle', 'end', 'justify'].filter(h => {
-                  if (h === 'justify') {
-                    const isAuto = (editingShape as any)?.props?.autoSize ?? true;
-                    return !isAuto;
-                  }
-                  return true;
-                }).map((h) => {
-                  const isActive = isEditingRichText ? richStats.align === h : getStyle(DefaultTextAlignStyle, 'start') === h;
-                  return (
-                    <button
-                      key={h}
-                      className={clsx(styles.iconBtn, isActive && styles.active)}
-                      onClick={() => {
-                        if (!hasMoved.current) {
-                          setStyle(DefaultTextAlignStyle, h);
-                        }
-                      }}
-                      onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                      title={t(`align_${h === 'middle' ? 'middle' : (h === 'end' ? 'end' : h)}`)}
-                    >
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                        <rect x="2" y="4" width="12" height="1.5" rx="0.75" />
-                        <rect
-                          x={h === 'start' ? 2 : (h === 'middle' ? 4 : (h === 'end' ? 6 : 2))}
-                          y="7.25"
-                          width={h === 'justify' ? 12 : 8} height="1.5" rx="0.75"
-                        />
-                        <rect
-                          x={h === 'start' ? 2 : (h === 'middle' ? 3 : (h === 'end' ? 4 : 2))}
-                          y="10.5"
-                          width={h === 'justify' ? 12 : 10} height="1.5" rx="0.75"
-                        />
-                      </svg>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-            <div className={styles.colorsRow}>
-              {colors.map(c => (
-                <button
-                  key={c}
-                  className={clsx(styles.colorSwatch, richStats.color === c && styles.activeColor)}
-                  style={{
-                    backgroundColor: colorsMap[c],
-                    boxShadow: richStats.color === c
-                      ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
-                      : undefined
-                  }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  onClick={() => !hasMoved.current && setStyle(DefaultColorStyle, c)}
-                />
-              ))}
-            </div>
-          </div>
+          <BubbleTextSection
+            richStats={richStats}
+            currentFont={currentFont}
+            currentSize={currentSize}
+            colorsMap={colorsMap}
+            colors={colors}
+            isEditingRichText={isEditingRichText}
+            editingShape={editingShape}
+            hasMoved={hasMoved}
+            setStyle={setStyle}
+            toggleStyle={toggleStyle}
+            getStyle={getStyle}
+            openLinkModal={openLinkModal}
+          />
         )}
+
         {showShapeTypeSection && (
-          <div className={styles.shapeSettings}>
-            <div className={styles.sectionHeader}>
-              <span className={styles.sectionTitle}>{t('tool_shapes')}</span>
-            </div>
-            {/* Shape Type Selection */}
-            <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
-              {['rectangle', 'ellipse', 'triangle', 'diamond', 'pentagon', 'hexagon', 'octagon'].map((shape) => {
-                const isActive = currentShapeOption === shape;
-                return (
-                  <button
-                    key={shape}
-                    className={clsx(styles.iconBtn, isActive && styles.active)}
-                    onClick={() => {
-                      if (!hasMoved.current) {
-                        editor.setCurrentTool('geo');
-                        setStyle(GeoShapeGeoStyle, shape);
-                      }
-                    }}
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    title={t(`tool_${shape === 'rectangle' ? 'square' : shape === 'ellipse' ? 'circle' : shape}`)}
-                  >
-                    {shape === 'rectangle' && <Square size={16} />}
-                    {shape === 'ellipse' && <Circle size={16} />}
-                    {shape === 'triangle' && <Triangle size={16} />}
-                    {shape === 'diamond' && <Diamond size={16} />}
-                    {shape === 'pentagon' && <Pentagon size={16} />}
-                    {shape === 'hexagon' && <Hexagon size={16} />}
-                    {shape === 'octagon' && <Octagon size={16} />}
-                  </button>
-                );
-              })}
-            </div>
-            <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
-              {['star', 'cloud', 'heart', 'oval', 'trapezoid', 'rhombus', 'x-box'].map((shape) => {
-                const isActive = currentShapeOption === shape;
-                return (
-                  <button
-                    key={shape}
-                    className={clsx(styles.iconBtn, isActive && styles.active)}
-                    onClick={() => {
-                      if (!hasMoved.current) {
-                        editor.setCurrentTool('geo');
-                        setStyle(GeoShapeGeoStyle, shape);
-                      }
-                    }}
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    title={t(`tool_${shape === 'x-box' ? 'star' : shape}`)}
-                  >
-                    {shape === 'star' && <Star size={16} />}
-                    {shape === 'cloud' && <Cloud size={16} />}
-                    {shape === 'heart' && <Heart size={16} />}
-                    {shape === 'oval' && <Circle size={16} />}
-                    {shape === 'trapezoid' && <TrapezoidIcon size={16} />}
-                    {shape === 'rhombus' && <Diamond size={16} />}
-                    {shape === 'x-box' && <X size={16} />}
-                  </button>
-                );
-              })}
-            </div>
-            <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
-              {['check-box', 'arrow-up', 'arrow-down', 'arrow-left', 'arrow-right', 'arrow', 'line'].map((shape) => {
-                const isActive = currentShapeOption === shape;
-                return (
-                  <button
-                    key={shape}
-                    className={clsx(styles.iconBtn, isActive && styles.active)}
-                    onClick={() => {
-                      if (!hasMoved.current) {
-                        if (shape === 'arrow' || shape === 'line') {
-                          editor.setCurrentTool(shape);
-                        } else {
-                          editor.setCurrentTool('geo');
-                          setStyle(GeoShapeGeoStyle, shape);
-                        }
-                      }
-                    }}
-                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    title={t(`tool_${shape}`)}
-                  >
-                    {shape === 'check-box' && <Check size={16} />}
-                    {shape === 'arrow-up' && <ArrowBigUp size={16} />}
-                    {shape === 'arrow-down' && <ArrowBigDown size={16} />}
-                    {shape === 'arrow-left' && <ArrowBigLeft size={16} />}
-                    {shape === 'arrow-right' && <ArrowBigRight size={16} />}
-                    {shape === 'arrow' && (
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ transform: 'rotate(45deg)' }}>
-                        <line x1="5" y1="12" x2="19" y2="12" />
-                        <polyline points="12 5 19 12 12 19" />
-                      </svg>
-                    )}
-                    {shape === 'line' && <Minus size={16} />}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+          <BubbleShapeSection
+            currentShapeOption={currentShapeOption}
+            hasMoved={hasMoved}
+            editor={editor}
+            setStyle={setStyle}
+          />
         )}
 
-        {/* STROKE SECTION */}
         {showStrokeSection && (
-          <div className={styles.strokeSettings}>
-            {!(activeTool === 'draw' || (isSelectTool && isAllDraw)) && (
-              <div className={styles.sectionHeader}>
-                <span className={styles.sectionTitle}>{t('style_stroke')}</span>
-                <button
-                  className={clsx(styles.switch, currentStrokeOpacity > 0 && styles.switchActive)}
-                  onClick={() => {
-                    const newOpacity = currentStrokeOpacity > 0 ? '0' : '1';
-                    // Safety: Don't allow both off. If turning off stroke, turn on fill.
-                    if (newOpacity === '0' && currentFill === 'none') {
-                      setStyle(DefaultFillStyle, 'solid');
-                      if (currentFillOpacity === 0) setStyle(FillOpacityStyle, '1');
-                    }
-                    setStyle(StrokeOpacityStyle, newOpacity);
-                  }}
-                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                >
-                  <div className={styles.switchHandle} />
-                </button>
-              </div>
-            )}
-
-            {currentStrokeOpacity > 0 && (
-              <>
-                <div className={styles.sizeRow}>
-                  {/* Dash Style */}
-                  <div className={styles.styleGroup}>
-                    {['draw', 'solid', 'dashed', 'dotted'].map((dash) => {
-                      const isActive = currentDash === dash;
-                      return (
-                        <button
-                          key={dash}
-                          className={clsx(styles.iconBtnCompact, isActive && styles.active)}
-                          onClick={() => {
-                            if (!hasMoved.current) {
-                              setStyle(DefaultDashStyle, dash);
-                            }
-                          }}
-                          onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                          title={t(`style_border_${dash}`)}
-                        >
-                          {dash === 'draw' ? (
-                            <Scribble strokeWidth={2} />
-                          ) : (
-                            <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
-                              {dash === 'solid' && <line x1="2" y1="10" x2="18" y2="10" />}
-                              {dash === 'dashed' && <line x1="2" y1="10" x2="18" y2="10" strokeDasharray="4 2" />}
-                              {dash === 'dotted' && <line x1="2" y1="10" x2="18" y2="10" strokeDasharray="1 2" />}
-                            </svg>
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  {showStrokeSection && (
-                    <>
-                      <div className={styles.verticalDivider} />
-                      <div className={styles.styleGroup} style={{ flex: 1, justifyContent: 'space-between' }}>
-                        {((activeTool === 'draw' || (isSelectTool && selectedShapes.every(s => s.type === 'draw'))) ? ['xs', 's', 'm', 'l', 'xl', 'xxl'] : ['s', 'm', 'l', 'xl']).map((sz) => {
-                          const strokeWidths: Record<string, number> = { xs: 1, s: 1.5, m: 2.5, l: 4, xl: 6, xxl: 10 };
-                          return (
-                            <button
-                              key={sz}
-                              className={clsx(styles.sizeBtnCompact, currentSize === sz && styles.active)}
-                              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                              onClick={() => !hasMoved.current && setStyle(DefaultSizeStyle, sz)}
-                            >
-                              <Scribble strokeWidth={strokeWidths[sz]} />
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </>
-                  )}
-                </div>
-
-                <div className={styles.colorsRow}>
-                  {colors.map(c => (
-                    <button
-                      key={c}
-                      className={clsx(styles.colorSwatch, currentColor === c && styles.activeColor)}
-                      style={{
-                        backgroundColor: colorsMap[c],
-                        boxShadow: currentColor === c
-                          ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
-                          : undefined
-                      }}
-                      onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                      onClick={() => !hasMoved.current && setStyle(DefaultColorStyle, c)}
-                    />
-                  ))}
-                </div>
-
-                {!(activeTool === 'draw' || (isSelectTool && isAllDraw)) && (
-                  <div className={styles.opacityRow}>
-                    <input
-                      type="range"
-                      min="10"
-                      max="100"
-                      value={currentStrokeOpacity * 100}
-                      onChange={(e) => {
-                        const newOpacity = (parseInt(e.target.value) / 100).toString();
-                        setStyle(StrokeOpacityStyle, newOpacity);
-                      }}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className={styles.opacitySlider}
-                    />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
+          <BubbleStrokeSection
+            activeTool={activeTool}
+            isSelectTool={isSelectTool}
+            isAllDraw={isAllDraw}
+            currentDash={currentDash}
+            currentSize={currentSize}
+            currentColor={currentColor}
+            currentStrokeOpacity={currentStrokeOpacity}
+            currentFill={currentFill}
+            currentFillOpacity={currentFillOpacity}
+            colorsMap={colorsMap}
+            colors={colors}
+            hasMoved={hasMoved}
+            setStyle={setStyle}
+          />
         )}
 
-        {/* FILL Section */}
         {showFillSection && (
-          <div className={styles.fillSettings}>
-            <div className={styles.sectionHeader}>
-              <span className={styles.sectionTitle}>{t('style_fill')}</span>
-              <button
-                className={clsx(styles.switch, currentFill !== 'none' && styles.switchActive)}
-                onClick={() => {
-                  if (currentFill === 'none') {
-                    setStyle(DefaultFillStyle, 'solid');
-                    // Reset opacity if it was 0
-                    if (currentFillOpacity === 0) setStyle(FillOpacityStyle, '1');
-                  } else {
-                    // Safety: if turning off fill, make sure stroke is on
-                    if (currentStrokeOpacity === 0) {
-                      setStyle(StrokeOpacityStyle, '1');
-                    }
-                    setStyle(DefaultFillStyle, 'none');
-                  }
-                }}
-                onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-              >
-                <div className={styles.switchHandle} />
-              </button>
-            </div>
-
-            {currentFill !== 'none' && (
-              <>
-                <div className={styles.colorsRow}>
-                  {colors.map(c => (
-                    <button
-                      key={c}
-                      className={clsx(styles.colorSwatch, currentFillColor === c && styles.activeColor)}
-                      style={{
-                        backgroundColor: colorsMap[c],
-                        boxShadow: currentFillColor === c
-                          ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
-                          : undefined
-                      }}
-                      onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                      onClick={() => !hasMoved.current && setStyle(FillColorStyle, c)}
-                    />
-                  ))}
-                </div>
-
-                <div className={styles.opacityRow}>
-                  <input
-                    type="range"
-                    min="10"
-                    max="100"
-                    value={currentFillOpacity * 100}
-                    onChange={(e) => {
-                      const newOpacity = (parseInt(e.target.value) / 100).toString();
-                      setStyle(FillOpacityStyle, newOpacity);
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    className={styles.opacitySlider}
-                  />
-                </div>
-              </>
-            )}
-          </div>
+          <BubbleFillSection
+            currentFill={currentFill}
+            currentFillColor={currentFillColor}
+            currentFillOpacity={currentFillOpacity}
+            currentStrokeOpacity={currentStrokeOpacity}
+            colorsMap={colorsMap}
+            colors={colors}
+            hasMoved={hasMoved}
+            setStyle={setStyle}
+          />
         )}
 
         {isLinkModalOpen && (
@@ -1442,6 +734,6 @@ export const Bubble = track(({ activeTool }: BubbleProps) => {
           />
         )}
       </div>
-    </UIPortal >
+    </UIPortal>
   );
 });

--- a/src/components/Bubble/icons/ScribbleIcon.tsx
+++ b/src/components/Bubble/icons/ScribbleIcon.tsx
@@ -1,0 +1,22 @@
+interface ScribbleIconProps {
+  strokeWidth: number;
+  color?: string;
+}
+
+/**
+ * Generic scribble SVG icon used for draw tool indicator.
+ */
+export const ScribbleIcon = ({ strokeWidth, color = 'currentColor' }: ScribbleIconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M4 14c2-4 5-6 8-2s6 2 8 0" />
+  </svg>
+);

--- a/src/components/Bubble/icons/TrapezoidIcon.tsx
+++ b/src/components/Bubble/icons/TrapezoidIcon.tsx
@@ -1,0 +1,21 @@
+interface TrapezoidIconProps {
+  size?: number;
+}
+
+/**
+ * Trapezoid shape icon for the shape selector.
+ */
+export const TrapezoidIcon = ({ size = 16 }: TrapezoidIconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 20 20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M6 5h8l4 10H2L6 5z" />
+  </svg>
+);

--- a/src/components/Bubble/icons/index.ts
+++ b/src/components/Bubble/icons/index.ts
@@ -1,0 +1,2 @@
+export { ScribbleIcon } from './ScribbleIcon';
+export { TrapezoidIcon } from './TrapezoidIcon';

--- a/src/components/Bubble/sections/BubbleCollapsed.tsx
+++ b/src/components/Bubble/sections/BubbleCollapsed.tsx
@@ -1,0 +1,91 @@
+import clsx from 'clsx';
+import { Shapes } from 'lucide-react';
+import styles from '../Bubble.module.css';
+import { ScribbleIcon } from '../icons';
+import { sizeMap, fontFamilies } from '../utils';
+
+interface RichStats {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strike: boolean;
+  font: string;
+  size: string;
+  color: string;
+  align: string;
+}
+
+interface BubbleCollapsedProps {
+  activeTool: string;
+  isEditingRichText: boolean;
+  isSelectTool: boolean;
+  isAllText: boolean;
+  isAllShape: boolean;
+  currentFont: string;
+  currentSize: string;
+  activeColorHex: string;
+  richStats: RichStats;
+  isDragging: boolean;
+  position: { x: number; y: number };
+  handlePointerDown: (e: React.PointerEvent) => void;
+  handleExpandCheck: () => void;
+}
+
+/**
+ * Collapsed view of the Bubble component.
+ * Shows a visual indicator based on the active tool.
+ */
+export const BubbleCollapsed = ({
+  activeTool,
+  isEditingRichText,
+  isSelectTool,
+  isAllText,
+  isAllShape,
+  currentFont,
+  currentSize,
+  activeColorHex,
+  richStats,
+  isDragging,
+  position,
+  handlePointerDown,
+  handleExpandCheck,
+}: BubbleCollapsedProps) => {
+  const isTextMode = activeTool === 'text' || isEditingRichText || (isSelectTool && isAllText);
+  const isShapeMode = activeTool === 'geo' || activeTool === 'arrow' || activeTool === 'line' || activeTool === 'shapes' || (isSelectTool && isAllShape);
+
+  return (
+    <div
+      className={clsx(styles.bubble, styles.collapsed, isDragging && styles.dragging)}
+      style={{
+        left: position.x,
+        top: position.y,
+        backgroundColor: 'var(--glass-bg)',
+        pointerEvents: 'auto'
+      }}
+      onPointerDown={(e) => { e.stopPropagation(); handlePointerDown(e); }}
+      onClick={handleExpandCheck}
+      data-is-ui="true"
+    >
+      {isTextMode ? (
+        <div style={{
+          fontFamily: fontFamilies[currentFont] || fontFamilies.sans,
+          color: activeColorHex,
+          fontSize: '24px',
+          fontWeight: richStats.bold ? 'bold' : 'normal',
+          fontStyle: richStats.italic ? 'italic' : 'normal',
+          textDecoration: [
+            richStats.underline ? 'underline' : '',
+            richStats.strike ? 'line-through' : ''
+          ].filter(Boolean).join(' ') || 'none',
+          pointerEvents: 'none'
+        }}>
+          A
+        </div>
+      ) : isShapeMode ? (
+        <Shapes size={24} />
+      ) : (
+        <ScribbleIcon strokeWidth={sizeMap[currentSize] || 2.5} color={activeColorHex} />
+      )}
+    </div>
+  );
+};

--- a/src/components/Bubble/sections/BubbleFillSection.tsx
+++ b/src/components/Bubble/sections/BubbleFillSection.tsx
@@ -1,0 +1,96 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { DefaultFillStyle } from 'tldraw';
+import styles from '../Bubble.module.css';
+import { FillColorStyle, FillOpacityStyle, StrokeOpacityStyle } from '../../../styles/customStyles';
+
+interface BubbleFillSectionProps {
+  currentFill: string;
+  currentFillColor: string;
+  currentFillOpacity: number;
+  currentStrokeOpacity: number;
+  colorsMap: Record<string, string>;
+  colors: string[];
+  hasMoved: React.MutableRefObject<boolean>;
+  setStyle: (style: any, value: any) => void;
+}
+
+/**
+ * Fill settings section of the Bubble component.
+ * Includes fill toggle, color selection, and opacity slider.
+ */
+export const BubbleFillSection = ({
+  currentFill,
+  currentFillColor,
+  currentFillOpacity,
+  currentStrokeOpacity,
+  colorsMap,
+  colors,
+  hasMoved,
+  setStyle,
+}: BubbleFillSectionProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.fillSettings}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionTitle}>{t('style_fill')}</span>
+        <button
+          className={clsx(styles.switch, currentFill !== 'none' && styles.switchActive)}
+          onClick={() => {
+            if (currentFill === 'none') {
+              setStyle(DefaultFillStyle, 'solid');
+              // Reset opacity if it was 0
+              if (currentFillOpacity === 0) setStyle(FillOpacityStyle, '1');
+            } else {
+              // Safety: if turning off fill, make sure stroke is on
+              if (currentStrokeOpacity === 0) {
+                setStyle(StrokeOpacityStyle, '1');
+              }
+              setStyle(DefaultFillStyle, 'none');
+            }
+          }}
+          onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+        >
+          <div className={styles.switchHandle} />
+        </button>
+      </div>
+
+      {currentFill !== 'none' && (
+        <>
+          <div className={styles.colorsRow}>
+            {colors.map(c => (
+              <button
+                key={c}
+                className={clsx(styles.colorSwatch, currentFillColor === c && styles.activeColor)}
+                style={{
+                  backgroundColor: colorsMap[c],
+                  boxShadow: currentFillColor === c
+                    ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
+                    : undefined
+                }}
+                onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                onClick={() => !hasMoved.current && setStyle(FillColorStyle, c)}
+              />
+            ))}
+          </div>
+
+          <div className={styles.opacityRow}>
+            <input
+              type="range"
+              min="10"
+              max="100"
+              value={currentFillOpacity * 100}
+              onChange={(e) => {
+                const newOpacity = (parseInt(e.target.value) / 100).toString();
+                setStyle(FillOpacityStyle, newOpacity);
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className={styles.opacitySlider}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/Bubble/sections/BubbleShapeSection.tsx
+++ b/src/components/Bubble/sections/BubbleShapeSection.tsx
@@ -1,0 +1,140 @@
+import clsx from 'clsx';
+import {
+  Square,
+  Circle,
+  Triangle,
+  Diamond,
+  Star,
+  Hexagon,
+  Cloud,
+  Heart,
+  Pentagon,
+  Octagon,
+  X,
+  Check,
+  ArrowBigUp,
+  ArrowBigDown,
+  ArrowBigLeft,
+  ArrowBigRight,
+  Minus,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { GeoShapeGeoStyle, Editor } from 'tldraw';
+import styles from '../Bubble.module.css';
+import { TrapezoidIcon } from '../icons';
+
+interface BubbleShapeSectionProps {
+  currentShapeOption: string;
+  hasMoved: React.MutableRefObject<boolean>;
+  editor: Editor;
+  setStyle: (style: any, value: any) => void;
+}
+
+/**
+ * Shape type selection section of the Bubble component.
+ * Includes geometric shapes, arrows, and lines.
+ */
+export const BubbleShapeSection = ({
+  currentShapeOption,
+  hasMoved,
+  editor,
+  setStyle,
+}: BubbleShapeSectionProps) => {
+  const { t } = useTranslation();
+
+  const handleShapeClick = (shape: string) => {
+    if (!hasMoved.current) {
+      if (shape === 'arrow' || shape === 'line') {
+        editor.setCurrentTool(shape);
+      } else {
+        editor.setCurrentTool('geo');
+        setStyle(GeoShapeGeoStyle, shape);
+      }
+    }
+  };
+
+  return (
+    <div className={styles.shapeSettings}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionTitle}>{t('tool_shapes')}</span>
+      </div>
+
+      {/* Row 1: Basic shapes */}
+      <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
+        {['rectangle', 'ellipse', 'triangle', 'diamond', 'pentagon', 'hexagon', 'octagon'].map((shape) => {
+          const isActive = currentShapeOption === shape;
+          return (
+            <button
+              key={shape}
+              className={clsx(styles.iconBtn, isActive && styles.active)}
+              onClick={() => handleShapeClick(shape)}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              title={t(`tool_${shape === 'rectangle' ? 'square' : shape === 'ellipse' ? 'circle' : shape}`)}
+            >
+              {shape === 'rectangle' && <Square size={16} />}
+              {shape === 'ellipse' && <Circle size={16} />}
+              {shape === 'triangle' && <Triangle size={16} />}
+              {shape === 'diamond' && <Diamond size={16} />}
+              {shape === 'pentagon' && <Pentagon size={16} />}
+              {shape === 'hexagon' && <Hexagon size={16} />}
+              {shape === 'octagon' && <Octagon size={16} />}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Row 2: Special shapes */}
+      <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
+        {['star', 'cloud', 'heart', 'oval', 'trapezoid', 'rhombus', 'x-box'].map((shape) => {
+          const isActive = currentShapeOption === shape;
+          return (
+            <button
+              key={shape}
+              className={clsx(styles.iconBtn, isActive && styles.active)}
+              onClick={() => handleShapeClick(shape)}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              title={t(`tool_${shape === 'x-box' ? 'star' : shape}`)}
+            >
+              {shape === 'star' && <Star size={16} />}
+              {shape === 'cloud' && <Cloud size={16} />}
+              {shape === 'heart' && <Heart size={16} />}
+              {shape === 'oval' && <Circle size={16} />}
+              {shape === 'trapezoid' && <TrapezoidIcon size={16} />}
+              {shape === 'rhombus' && <Diamond size={16} />}
+              {shape === 'x-box' && <X size={16} />}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Row 3: Arrows and lines */}
+      <div className={styles.styleGroup} style={{ justifyContent: 'space-between' }}>
+        {['check-box', 'arrow-up', 'arrow-down', 'arrow-left', 'arrow-right', 'arrow', 'line'].map((shape) => {
+          const isActive = currentShapeOption === shape;
+          return (
+            <button
+              key={shape}
+              className={clsx(styles.iconBtn, isActive && styles.active)}
+              onClick={() => handleShapeClick(shape)}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              title={t(`tool_${shape}`)}
+            >
+              {shape === 'check-box' && <Check size={16} />}
+              {shape === 'arrow-up' && <ArrowBigUp size={16} />}
+              {shape === 'arrow-down' && <ArrowBigDown size={16} />}
+              {shape === 'arrow-left' && <ArrowBigLeft size={16} />}
+              {shape === 'arrow-right' && <ArrowBigRight size={16} />}
+              {shape === 'arrow' && (
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ transform: 'rotate(45deg)' }}>
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              )}
+              {shape === 'line' && <Minus size={16} />}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Bubble/sections/BubbleStrokeSection.tsx
+++ b/src/components/Bubble/sections/BubbleStrokeSection.tsx
@@ -1,0 +1,161 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { DefaultDashStyle, DefaultSizeStyle, DefaultColorStyle, DefaultFillStyle } from 'tldraw';
+import styles from '../Bubble.module.css';
+import { ScribbleIcon } from '../icons';
+import { FillOpacityStyle, StrokeOpacityStyle } from '../../../styles/customStyles';
+
+interface BubbleStrokeSectionProps {
+  activeTool: string;
+  isSelectTool: boolean;
+  isAllDraw: boolean;
+  currentDash: string;
+  currentSize: string;
+  currentColor: string;
+  currentStrokeOpacity: number;
+  currentFill: string;
+  currentFillOpacity: number;
+  colorsMap: Record<string, string>;
+  colors: string[];
+  hasMoved: React.MutableRefObject<boolean>;
+  setStyle: (style: any, value: any) => void;
+}
+
+/**
+ * Stroke settings section of the Bubble component.
+ * Includes dash style, size, color, and opacity controls.
+ */
+export const BubbleStrokeSection = ({
+  activeTool,
+  isSelectTool,
+  isAllDraw,
+  currentDash,
+  currentSize,
+  currentColor,
+  currentStrokeOpacity,
+  currentFill,
+  currentFillOpacity,
+  colorsMap,
+  colors,
+  hasMoved,
+  setStyle,
+}: BubbleStrokeSectionProps) => {
+  const { t } = useTranslation();
+
+  const isDrawMode = activeTool === 'draw' || (isSelectTool && isAllDraw);
+  const showHeader = !isDrawMode;
+
+  return (
+    <div className={styles.strokeSettings}>
+      {showHeader && (
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionTitle}>{t('style_stroke')}</span>
+          <button
+            className={clsx(styles.switch, currentStrokeOpacity > 0 && styles.switchActive)}
+            onClick={() => {
+              const newOpacity = currentStrokeOpacity > 0 ? '0' : '1';
+              // Safety: Don't allow both off. If turning off stroke, turn on fill.
+              if (newOpacity === '0' && currentFill === 'none') {
+                setStyle(DefaultFillStyle, 'solid');
+                if (currentFillOpacity === 0) setStyle(FillOpacityStyle, '1');
+              }
+              setStyle(StrokeOpacityStyle, newOpacity);
+            }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+          >
+            <div className={styles.switchHandle} />
+          </button>
+        </div>
+      )}
+
+      {currentStrokeOpacity > 0 && (
+        <>
+          <div className={styles.sizeRow}>
+            {/* Dash Style */}
+            <div className={styles.styleGroup}>
+              {['draw', 'solid', 'dashed', 'dotted'].map((dash) => {
+                const isActive = currentDash === dash;
+                return (
+                  <button
+                    key={dash}
+                    className={clsx(styles.iconBtnCompact, isActive && styles.active)}
+                    onClick={() => {
+                      if (!hasMoved.current) {
+                        setStyle(DefaultDashStyle, dash);
+                      }
+                    }}
+                    onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                    title={t(`style_border_${dash}`)}
+                  >
+                    {dash === 'draw' ? (
+                      <ScribbleIcon strokeWidth={2} />
+                    ) : (
+                      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
+                        {dash === 'solid' && <line x1="2" y1="10" x2="18" y2="10" />}
+                        {dash === 'dashed' && <line x1="2" y1="10" x2="18" y2="10" strokeDasharray="4 2" />}
+                        {dash === 'dotted' && <line x1="2" y1="10" x2="18" y2="10" strokeDasharray="1 2" />}
+                      </svg>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            <>
+              <div className={styles.verticalDivider} />
+              <div className={styles.styleGroup} style={{ flex: 1, justifyContent: 'space-between' }}>
+                {(isDrawMode ? ['xs', 's', 'm', 'l', 'xl', 'xxl'] : ['s', 'm', 'l', 'xl']).map((sz) => {
+                  const strokeWidths: Record<string, number> = { xs: 1, s: 1.5, m: 2.5, l: 4, xl: 6, xxl: 10 };
+                  return (
+                    <button
+                      key={sz}
+                      className={clsx(styles.sizeBtnCompact, currentSize === sz && styles.active)}
+                      onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                      onClick={() => !hasMoved.current && setStyle(DefaultSizeStyle, sz)}
+                    >
+                      <ScribbleIcon strokeWidth={strokeWidths[sz]} />
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          </div>
+
+          <div className={styles.colorsRow}>
+            {colors.map(c => (
+              <button
+                key={c}
+                className={clsx(styles.colorSwatch, currentColor === c && styles.activeColor)}
+                style={{
+                  backgroundColor: colorsMap[c],
+                  boxShadow: currentColor === c
+                    ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
+                    : undefined
+                }}
+                onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                onClick={() => !hasMoved.current && setStyle(DefaultColorStyle, c)}
+              />
+            ))}
+          </div>
+
+          {!isDrawMode && (
+            <div className={styles.opacityRow}>
+              <input
+                type="range"
+                min="10"
+                max="100"
+                value={currentStrokeOpacity * 100}
+                onChange={(e) => {
+                  const newOpacity = (parseInt(e.target.value) / 100).toString();
+                  setStyle(StrokeOpacityStyle, newOpacity);
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className={styles.opacitySlider}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/Bubble/sections/BubbleTextSection.tsx
+++ b/src/components/Bubble/sections/BubbleTextSection.tsx
@@ -1,0 +1,203 @@
+import clsx from 'clsx';
+import {
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  Link as LinkIcon,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { DefaultFontStyle, DefaultSizeStyle, DefaultColorStyle, DefaultTextAlignStyle } from 'tldraw';
+import styles from '../Bubble.module.css';
+
+interface RichStats {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strike: boolean;
+  font: string;
+  size: string;
+  color: string;
+  align: string;
+}
+
+interface BubbleTextSectionProps {
+  richStats: RichStats;
+  currentFont: string;
+  currentSize: string;
+  colorsMap: Record<string, string>;
+  colors: string[];
+  isEditingRichText: boolean;
+  editingShape: any;
+  hasMoved: React.MutableRefObject<boolean>;
+  setStyle: (style: any, value: any) => void;
+  toggleStyle: (command: string) => void;
+  getStyle: (style: any, fallback: string) => any;
+  openLinkModal: (e: React.MouseEvent) => void;
+}
+
+/**
+ * Text settings section of the Bubble component.
+ * Includes font, size, format buttons, alignment, and color selection.
+ */
+export const BubbleTextSection = ({
+  richStats,
+  currentFont,
+  currentSize,
+  colorsMap,
+  colors,
+  isEditingRichText,
+  editingShape,
+  hasMoved,
+  setStyle,
+  toggleStyle,
+  getStyle,
+  openLinkModal,
+}: BubbleTextSectionProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.textSettings}>
+      <div className={styles.topRow}>
+        <div className={styles.textToolsRow}>
+          {['draw', 'sans', 'serif', 'mono'].map(f => (
+            <button
+              key={f}
+              className={clsx(styles.iconBtnTiny, currentFont === f && styles.active)}
+              style={{
+                fontFamily: `var(--font-${f})`,
+                fontSize: '16px',
+                fontWeight: 'bold',
+              }}
+              onClick={() => setStyle(DefaultFontStyle, f)}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              title={t(`font_${f}`)}
+            >
+              A
+            </button>
+          ))}
+          <div className={styles.verticalDivider} />
+          {['xs', 's', 'm', 'l', 'xl', 'xxl'].map(s => (
+            <button
+              key={s}
+              className={clsx(styles.iconBtnTiny, currentSize === s && styles.active)}
+              style={{
+                fontSize: s === 'xs' ? '10px' :
+                  s === 's' ? '12px' :
+                    s === 'm' ? '14px' :
+                      s === 'l' ? '18px' :
+                        s === 'xl' ? '22px' : '26px',
+                fontWeight: 'bold',
+              }}
+              onClick={() => setStyle(DefaultSizeStyle, s)}
+              onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              title={t(`font_size_${s}`)}
+            >
+              A
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.toolsRow}>
+        <div className={styles.styleGroup}>
+          <button
+            className={clsx(styles.iconBtn, richStats.bold && styles.active)}
+            onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('bold'); }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            title={t('format_bold')}
+          >
+            <Bold strokeWidth={2.5} size={16} />
+          </button>
+          <button
+            className={clsx(styles.iconBtn, richStats.italic && styles.active)}
+            onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('italic'); }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            title={t('format_italic')}
+          >
+            <Italic strokeWidth={2.5} size={16} />
+          </button>
+          <button
+            className={clsx(styles.iconBtn, richStats.underline && styles.active)}
+            onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('underline'); }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            title={t('format_underline')}
+          >
+            <Underline strokeWidth={2.5} size={16} />
+          </button>
+          <button
+            className={clsx(styles.iconBtn, richStats.strike && styles.active)}
+            onClick={(e) => { e.stopPropagation(); if (!hasMoved.current) toggleStyle('strikethrough'); }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            title={t('format_strikethrough')}
+          >
+            <Strikethrough strokeWidth={2.5} size={16} />
+          </button>
+          <div className={styles.verticalDivider} />
+          <button
+            className={styles.iconBtn}
+            onClick={openLinkModal}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            title={t('format_link')}
+          >
+            <LinkIcon size={16} />
+          </button>
+          <div className={styles.verticalDivider} />
+        </div>
+        <div className={styles.styleGroup}>
+          {['start', 'middle', 'end', 'justify'].filter(h => {
+            if (h === 'justify') {
+              const isAuto = (editingShape as any)?.props?.autoSize ?? true;
+              return !isAuto;
+            }
+            return true;
+          }).map((h) => {
+            const isActive = isEditingRichText ? richStats.align === h : getStyle(DefaultTextAlignStyle, 'start') === h;
+            return (
+              <button
+                key={h}
+                className={clsx(styles.iconBtn, isActive && styles.active)}
+                onClick={() => {
+                  if (!hasMoved.current) {
+                    setStyle(DefaultTextAlignStyle, h);
+                  }
+                }}
+                onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                title={t(`align_${h === 'middle' ? 'middle' : (h === 'end' ? 'end' : h)}`)}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <rect x="2" y="4" width="12" height="1.5" rx="0.75" />
+                  <rect
+                    x={h === 'start' ? 2 : (h === 'middle' ? 4 : (h === 'end' ? 6 : 2))}
+                    y="7.25"
+                    width={h === 'justify' ? 12 : 8} height="1.5" rx="0.75"
+                  />
+                  <rect
+                    x={h === 'start' ? 2 : (h === 'middle' ? 3 : (h === 'end' ? 4 : 2))}
+                    y="10.5"
+                    width={h === 'justify' ? 12 : 10} height="1.5" rx="0.75"
+                  />
+                </svg>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className={styles.colorsRow}>
+        {colors.map(c => (
+          <button
+            key={c}
+            className={clsx(styles.colorSwatch, richStats.color === c && styles.activeColor)}
+            style={{
+              backgroundColor: colorsMap[c],
+              boxShadow: richStats.color === c
+                ? `0 0 0 2px var(--glass-bg), 0 0 0 4px ${colorsMap[c]}`
+                : undefined
+            }}
+            onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            onClick={() => !hasMoved.current && setStyle(DefaultColorStyle, c)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Bubble/sections/index.ts
+++ b/src/components/Bubble/sections/index.ts
@@ -1,0 +1,5 @@
+export { BubbleCollapsed } from './BubbleCollapsed';
+export { BubbleTextSection } from './BubbleTextSection';
+export { BubbleShapeSection } from './BubbleShapeSection';
+export { BubbleStrokeSection } from './BubbleStrokeSection';
+export { BubbleFillSection } from './BubbleFillSection';

--- a/src/components/Bubble/utils/index.ts
+++ b/src/components/Bubble/utils/index.ts
@@ -1,0 +1,1 @@
+export { sizeMap, fontFamilies, fontSizes, applyStyleToRichText } from './richTextUtils';

--- a/src/components/Bubble/utils/richTextUtils.ts
+++ b/src/components/Bubble/utils/richTextUtils.ts
@@ -1,0 +1,125 @@
+/**
+ * Size mapping from string keys to stroke width numbers.
+ */
+export const sizeMap: Record<string, number> = {
+  xs: 1,
+  s: 1.5,
+  m: 2.5,
+  l: 4,
+  xl: 6,
+  xxl: 10,
+};
+
+/**
+ * Font family mappings for rich text styling.
+ */
+export const fontFamilies: Record<string, string> = {
+  draw: '"Comic Sans MS", "Chalkboard SE", "Comic Neue", sans-serif',
+  sans: 'Inter, sans-serif',
+  serif: 'serif',
+  mono: 'monospace'
+};
+
+/**
+ * Font size mappings for execCommand (fontSize uses 1-7 scale).
+ */
+export const fontSizes: Record<string, string> = {
+  xs: '3',
+  s: '4',
+  m: '5',
+  l: '6',
+  xl: '7',
+  xxl: '7'
+};
+
+/**
+ * Applies a style strictly to all elements within the rich-text content,
+ * preserving structure but enforcing the new property value on every node.
+ * This replaces the old "unify" behavior which stripped styles and wrapped globally.
+ */
+export const applyStyleToRichText = (html: string, prop: string, value: any): string => {
+  if (!html) return html;
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = html;
+
+  const elements = Array.from(tempDiv.querySelectorAll('*'));
+
+  if (elements.length === 0 && tempDiv.textContent?.trim()) {
+    // If pure text, wrap it so we can style it
+    const wrapper = document.createElement('span');
+    while (tempDiv.firstChild) {
+      wrapper.appendChild(tempDiv.firstChild);
+    }
+    tempDiv.appendChild(wrapper);
+    elements.push(wrapper);
+  }
+
+  elements.forEach((el) => {
+    const htmlEl = el as HTMLElement;
+
+    if (prop === 'color') {
+      htmlEl.style.color = value;
+    }
+    if (prop === 'font') {
+      htmlEl.style.fontFamily = fontFamilies[value] || 'sans-serif';
+    }
+    if (prop === 'size') htmlEl.style.fontSize = '';
+
+    if (prop === 'size') htmlEl.style.fontSize = '';
+    if (prop === 'font') htmlEl.style.fontFamily = '';
+    if (prop === 'align') htmlEl.style.textAlign = '';
+
+    // Toggles
+    if (prop === 'bold') {
+      if (value) {
+        htmlEl.style.fontWeight = 'bold';
+      } else {
+        htmlEl.style.fontWeight = 'normal';
+        if (htmlEl.tagName === 'B' || htmlEl.tagName === 'STRONG') {
+          htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
+        }
+      }
+    }
+    if (prop === 'italic') {
+      if (value) {
+        htmlEl.style.fontStyle = 'italic';
+      } else {
+        htmlEl.style.fontStyle = 'normal';
+        if (htmlEl.tagName === 'I' || htmlEl.tagName === 'EM') {
+          htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
+        }
+      }
+    }
+    if (prop === 'underline') {
+      const current = htmlEl.style.textDecoration;
+      let parts = current.split(' ').map(s => s.trim()).filter(Boolean);
+      if (value) {
+        if (!parts.includes('underline')) parts.push('underline');
+      } else {
+        parts = parts.filter(p => p !== 'underline');
+        if (htmlEl.tagName === 'U') {
+          htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
+          return; // Element is gone, stop processing it
+        }
+      }
+      htmlEl.style.textDecoration = parts.join(' ');
+    }
+    if (prop === 'strike') {
+      const current = htmlEl.style.textDecoration;
+      let parts = current.split(' ').map(s => s.trim()).filter(Boolean);
+      if (value) {
+        // 'line-through' is standard
+        if (!parts.includes('line-through')) parts.push('line-through');
+      } else {
+        parts = parts.filter(p => p !== 'line-through');
+        if (htmlEl.tagName === 'S' || htmlEl.tagName === 'STRIKE' || htmlEl.tagName === 'DEL') {
+          htmlEl.replaceWith(...Array.from(htmlEl.childNodes));
+          return; // Element is gone
+        }
+      }
+      htmlEl.style.textDecoration = parts.join(' ');
+    }
+  });
+
+  return tempDiv.innerHTML;
+};

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -1,16 +1,7 @@
 import {
   Tldraw,
   useEditor,
-  createShapeId,
   track,
-  DefaultColorStyle,
-  DefaultSizeStyle,
-  DefaultFontStyle,
-  DefaultDashStyle,
-  DefaultFillStyle,
-  DefaultTextAlignStyle,
-  GeoShapeGeoStyle,
-  transact,
   DefaultContextMenu
 } from 'tldraw'
 import 'tldraw/tldraw.css'
@@ -19,28 +10,34 @@ import { Toolbar } from '../Toolbar/Toolbar';
 import { Bubble } from '../Bubble/Bubble';
 import { useEffect, useRef, useState } from 'react';
 import { getIsDarkMode } from '../../lib/themeUtils';
-import {
-  LocateFixed,
-  PanelLeftOpen,
-  PanelRightOpen,
-  Undo2,
-  Redo2
-} from 'lucide-react';
+import { LocateFixed } from 'lucide-react';
 import { CircularButton } from '../UI/CircularButton';
 import { useFileSystemStore } from '../../store/fileSystemStore';
-import { useSyncStore } from '../../store/syncStore'; // Assuming this is the correct path, user provided 'useSyncStore'
+import { useSyncStore } from '../../store/syncStore';
 import { useUserPreferencesStore } from '../../store/userPreferencesStore';
-import { opfs } from '../../lib/opfs';
 import { RichTextShapeUtil } from '../../shapes/RichTextShapeUtil';
 import { CustomGeoShapeUtil } from '../../shapes/CustomGeoShapeUtil';
 import { CustomDrawShapeUtil } from '../../shapes/CustomDrawShapeUtil';
 import { CustomLineShapeUtil } from '../../shapes/CustomLineShapeUtil';
 import { CustomArrowShapeUtil } from '../../shapes/CustomArrowShapeUtil';
-import { syncLog } from '../../lib/debugLog';
-import { CanvasTitle } from './CanvasTitle';
-import { UIPortal } from '../UIPortal';
 import { useTranslation } from 'react-i18next';
-import clsx from 'clsx'; // Added clsx for HistoryControls
+
+// Extracted Components
+import { CenterMark } from './CenterMark';
+import { DebugOverlay } from './DebugOverlay';
+import { HistoryControls } from './HistoryControls';
+import { WelcomeScreen } from './WelcomeScreen';
+
+// Extracted Hooks
+import { usePageLoading } from '../../hooks/usePageLoading';
+import { usePagePersistence } from '../../hooks/usePagePersistence';
+import { useEraserOverride } from '../../hooks/useEraserOverride';
+import { useTouchPanning } from '../../hooks/useTouchPanning';
+import { useCanvasInteractions } from '../../hooks/useCanvasInteractions';
+import { useLongPressBlocker } from '../../hooks/useLongPressBlocker';
+import { useStyleMemory } from '../../hooks/useStyleMemory';
+import { useSidebarPanning } from '../../hooks/useSidebarPanning';
+import { useRecenter } from '../../hooks/useRecenter';
 
 const customShapeUtils = [
   RichTextShapeUtil,
@@ -50,1164 +47,73 @@ const customShapeUtils = [
   CustomArrowShapeUtil
 ];
 
-
-const CenterMark = track(() => {
-  const isDebug = new URLSearchParams(window.location.search).get('debug') === 'true';
-  if (!isDebug) return null;
-
-  const editor = useEditor();
-  const screenPoint = editor.pageToScreen({ x: 0, y: 0 });
-
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: screenPoint.x,
-        top: screenPoint.y,
-        transform: 'translate(-50%, -50%)',
-        pointerEvents: 'none',
-        zIndex: 999,
-        opacity: 0.8,
-        color: '#ff0000',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center'
-      }}
-    >
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <line x1="12" y1="4" x2="12" y2="20" />
-        <line x1="4" y1="12" x2="20" y2="12" />
-        <circle cx="12" cy="12" r="3" fill="currentColor" />
-      </svg>
-    </div>
-  );
-});
-
-const DebugOverlay = track(({ sidebarColumns }: { sidebarColumns: number }) => {
-  const isDebug = new URLSearchParams(window.location.search).get('debug') === 'true';
-  if (!isDebug) return null;
-
-  const editor = useEditor();
-  const { x, y, z } = editor.getCamera();
-  const [screen, setScreen] = useState({ w: window.innerWidth, h: window.innerHeight });
-
-  useEffect(() => {
-    const handleResize = () => setScreen({ w: window.innerWidth, h: window.innerHeight });
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const columnWidth = 250;
-  const margin = 12;
-  const sidebarWidth = sidebarColumns > 0 ? (columnWidth * sidebarColumns + margin * 2) : 0;
-  const viewportCenter = (screen.w + sidebarWidth) / 2;
-
-  // Normalized X: 0 means perfectly centered in the available space
-  const normalizedX = x - (viewportCenter / z);
-
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        top: '1rem',
-        right: '4.5rem',
-        zIndex: 1000,
-        background: 'var(--glass-bg)',
-        backdropFilter: 'blur(var(--glass-blur))',
-        WebkitBackdropFilter: 'blur(var(--glass-blur))',
-        padding: '0.4rem 0.8rem',
-        borderRadius: 'var(--radius-md)',
-        border: '1px solid var(--glass-border)',
-        fontSize: '11px',
-        color: 'hsl(var(--color-text-secondary))',
-        fontFamily: 'monospace',
-        pointerEvents: 'none',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '2px',
-        boxShadow: 'var(--shadow-md)'
-      }}
-    >
-      <div title="Actual Camera">CAM: {x.toFixed(0)}, {y.toFixed(0)}, {z.toFixed(2)}</div>
-      <div title="Normalized (Universal) Camera" style={{ color: 'var(--color-accent)' }}>NORM: {normalizedX.toFixed(0)}</div>
-      <div>WIN: {screen.w}x{screen.h}</div>
-      <div>SIDE: {sidebarWidth}px</div>
-    </div>
-  );
-});
-
-const HistoryControls = track(({ sidebarColumns, leftHandedMode }: { sidebarColumns: number, leftHandedMode: boolean }) => {
-  const editor = useEditor();
-  const { t } = useTranslation();
-
-  const canUndo = editor.getCanUndo();
-  const canRedo = editor.getCanRedo();
-
-  const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-
-  return (
-    <div
-      className={styles.historyControls}
-      style={{
-        [leftHandedMode ? 'right' : 'left']: `calc(${sidebarWidth}px + 1rem)`,
-        [leftHandedMode ? 'left' : 'right']: 'auto'
-      } as React.CSSProperties}
-    >
-      <CircularButton
-        onClick={() => editor.undo()}
-        disabled={!canUndo}
-        title={t('undo')}
-        icon={<Undo2 size={20} />}
-        className={clsx(styles.historyButton, !canUndo && styles.disabled)}
-      />
-      <CircularButton
-        onClick={() => editor.redo()}
-        disabled={!canRedo}
-        title={t('redo')}
-        icon={<Redo2 size={20} />}
-        className={clsx(styles.historyButton, !canRedo && styles.disabled)}
-      />
-    </div>
-  );
-});
-
 interface CanvasInterfaceProps {
   pageId: string;
   isDark: boolean;
 }
 
-
-// Main Component Logic (Reactive)
-const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, isDark, parentRef, sidebarColumns, leftHandedMode }: CanvasInterfaceProps & { pageVersion: number, lastModifier?: string, clientId: string, parentRef: React.RefObject<HTMLDivElement | null>, sidebarColumns: number, leftHandedMode: boolean }) => {
-  const { t, i18n } = useTranslation();
+const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, parentRef, sidebarColumns, leftHandedMode }: CanvasInterfaceProps & { pageVersion: number, lastModifier?: string, clientId: string, parentRef: React.RefObject<HTMLDivElement | null>, sidebarColumns: number, leftHandedMode: boolean }) => {
+  const { t } = useTranslation();
   const editor = useEditor();
-  // State to prevent flickering when switching focus between text shapes
   const forceTextModeRef = useRef(false);
   const [isLockingUI, setIsLockingUI] = useState(false);
   const [manualTool, setManualTool] = useState<string>('select');
 
-  const { isSidebarOpen, toggleSidebar } = useFileSystemStore();
-  const userPrefs = useUserPreferencesStore();
 
-  const lastLoadRef = useRef<{ pageId: string | null; version: number | null }>({ pageId: null, version: null });
+  const userPrefs = useUserPreferencesStore();
   const isLoadingRef = useRef(false);
 
-  // Load Snapshot
-  useEffect(() => {
-    if (!pageId) return;
+  // Use Extracted Hooks
+  const { lastGeoToolRef } = useStyleMemory(editor);
 
-    const loadPage = async () => {
-      isLoadingRef.current = true; // Prevent saves during load
+  usePageLoading(editor, pageId, pageVersion, lastModifier, clientId, userPrefs, sidebarColumns, leftHandedMode, isLoadingRef);
+  usePagePersistence(editor, pageId, sidebarColumns, leftHandedMode, isLoadingRef);
+  useEraserOverride(editor);
+  useTouchPanning(editor);
+  useCanvasInteractions(editor, parentRef, manualTool, setIsLockingUI, userPrefs, lastGeoToolRef);
+  useLongPressBlocker(editor);
+  useSidebarPanning(editor, sidebarColumns, leftHandedMode);
 
-      const json = await opfs.loadFile(`page-${pageId}.tldr`);
-      if (json && json !== '{}' && json !== '') {
-        try {
-          const snapshot = JSON.parse(json);
-          editor.loadSnapshot(snapshot);
+  const { handleRecenter, handleRecenterAll } = useRecenter(editor, sidebarColumns, leftHandedMode);
 
-          // Denormalize camera: Restore position relative to the center of the NEW viewport
-          if (snapshot.camera) {
-            const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-            const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
-            const viewportHalfHeight = window.innerHeight / 2;
-
-            // visualX = diskX + (center / zoom)
-            const actualX = snapshot.camera.x + (viewportCenter / snapshot.camera.z);
-            const actualY = snapshot.camera.y + (viewportHalfHeight / snapshot.camera.z);
-
-            syncLog(`📥 [CENTERING] Restoring: DiskX ${snapshot.camera.x.toFixed(0)} -> VisualX ${actualX.toFixed(0)}`);
-            editor.setCamera({ x: actualX, y: actualY, z: snapshot.camera.z });
-          } else {
-            // Document exists but no camera? Default to centered origin
-            const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-            const viewportHalfWidth = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
-            const viewportHalfHeight = window.innerHeight / 2;
-            const centerX = viewportHalfWidth;
-            const centerY = viewportHalfHeight;
-            editor.setCamera({ x: centerX, y: centerY, z: 1 });
-          }
-
-          // 1. Override isShapeErasable to only allow erasing 'draw' (handwriting) shapes
-          const originalIsErasable = (editor as any).isShapeErasable ? (editor as any).isShapeErasable.bind(editor) : null;
-
-          // Try both new and old names just in case
-          (editor as any).isErasable = (shape: any) => {
-            if (editor.getCurrentToolId() === 'eraser') return shape.type === 'draw';
-            return originalIsErasable ? originalIsErasable(shape) : true;
-          };
-          (editor as any).isShapeErasable = (editor as any).isErasable;
-
-          // 💡 PRIMING with User Preferences
-          editor.setStyleForNextShapes(DefaultColorStyle, userPrefs.textColor);
-          editor.setStyleForNextShapes(DefaultSizeStyle, userPrefs.textSize);
-          editor.setStyleForNextShapes(DefaultFontStyle, userPrefs.textFont);
-          editor.setStyleForNextShapes(DefaultTextAlignStyle, userPrefs.textAlign === 'justify' ? 'start' : userPrefs.textAlign as any);
-          editor.setStyleForNextShapes(DefaultDashStyle, userPrefs.dashStyle as any);
-          editor.setStyleForNextShapes(DefaultFillStyle, userPrefs.fillStyle as any);
-          editor.setStyleForNextShapes(GeoShapeGeoStyle, userPrefs.lastUsedGeo as any);
-        } catch (e) {
-          console.error("Failed to load snapshot", e);
-        }
-      } else {
-        // New or Empty page: EXPLICITLY clear shapes to prevent bleed
-        const shapeIds = editor.getCurrentPageShapeIds();
-        if (shapeIds.size > 0) {
-          editor.deleteShapes(Array.from(shapeIds));
-        }
-
-        // Center on origin (0,0) taking sidebar into account
-        const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-        const viewportHalfWidth = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
-        const viewportHalfHeight = window.innerHeight / 2;
-        const centerX = viewportHalfWidth;
-        const centerY = viewportHalfHeight;
-        editor.setCamera({ x: centerX, y: centerY, z: 1 });
-      }
-
-      // Delay to ensure all load-related events have settled
-      // 500ms provides a safer buffer against false-positive auto-saves
-      setTimeout(() => {
-        isLoadingRef.current = false;
-      }, 500);
-    };
-
-    const isNewPage = pageId !== lastLoadRef.current.pageId;
-    // Reload if: 1. It's a version change AND (modifier is different OR modifier is unknown)
-    const isRemoteChange = !isNewPage && pageVersion !== lastLoadRef.current.version && (!lastModifier || lastModifier !== clientId);
-
-    if (isNewPage || isRemoteChange) {
-      loadPage();
-      lastLoadRef.current = { pageId, version: pageVersion };
-    }
-
-  }, [editor, pageId, pageVersion, lastModifier, clientId, userPrefs, sidebarColumns, leftHandedMode]);
-
-  // Save Snapshot Listener
-  const hasUnsavedChangesRef = useRef(false);
-  const lastCameraRef = useRef({ x: 0, y: 0, z: 1 });
-  useEffect(() => {
-    if (!pageId) return;
-
-    const save = async () => {
-      // No guardar mientras se está cargando para evitar pisotear datos
-      if (isLoadingRef.current) {
-        syncLog(`[CENTERING] 🚫 Guardado cancelado: Cargando página.`);
-        return;
-      }
-
-      if (!hasUnsavedChangesRef.current) {
-        return;
-      }
-
-      const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-      const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
-      const viewportHalfHeight = window.innerHeight / 2;
-
-      const fullSnapshot = editor.getSnapshot();
-
-      // Obtener todos los registros directamente del store (método más fiable en v4)
-      const allRecordsArray = editor.store.allRecords();
-
-      // Filtramos records transitorios
-      const filteredRecords = allRecordsArray.filter(r =>
-        r.typeName !== 'instance' &&
-        r.typeName !== 'pointer' &&
-        r.typeName !== 'camera'
-      );
-
-      // Convertimos el array de nuevo a un objeto Record<ID, Record>
-      const filteredStore = Object.fromEntries(filteredRecords.map(r => [r.id, r]));
-
-      const { x, y, z } = editor.getCamera();
-      // Normalización de cámara
-      const normalizedX = x - (viewportCenter / z);
-      const normalizedY = y - (viewportHalfHeight / z);
-
-      // Creamos el snapshot con la estructura que tldraw espera
-      // Si fullSnapshot tiene 'store' y 'schema', seguimos ese patrón
-      const filteredSnapshot = {
-        store: filteredStore,
-        schema: (fullSnapshot as any).schema || (editor.store as any).schema?.serialize() || {},
-        camera: { x: normalizedX, y: normalizedY, z }
-      };
-
-      try {
-        const serialized = JSON.stringify(filteredSnapshot);
-        await opfs.saveFile(`page-${pageId}.tldr`, serialized);
-
-        // Señalizar cambio para sincronización
-        useFileSystemStore.getState().markPageDirty(pageId);
-
-        syncLog(`🔶 [CENTERING] Disco guardado: ${filteredRecords.length} reg. Pos: {x: ${normalizedX.toFixed(0)}, y: ${normalizedY.toFixed(0)}}`);
-      } catch (err) {
-        console.error(`[CENTERING] ❌ ERROR AL ESCRIBIR EN DISCO:`, err);
-      }
-
-      hasUnsavedChangesRef.current = false;
-    };
-
-    // Register this save function to be called before sync
-    useFileSystemStore.getState().registerActivePageSaver(save);
-
-    let timeout: any;
-    const handleSave = () => {
-      hasUnsavedChangesRef.current = true;
-      clearTimeout(timeout);
-      timeout = setTimeout(save, 500);
-    };
-
-    const cleanup = editor.store.listen((event) => {
-      // Ignore events during page load
-      if (isLoadingRef.current) return;
-
-      const { added, updated, removed } = event.changes;
-
-      // LOG EVERYTHING for debugging
-      // Object.values(updated).forEach(([, to]: any) => console.log(`[CENTERING] 📝 Record update: ${to.typeName}`));
-
-      // Check if any relevant records (shapes or camera) were modified
-      const hasRelevantChanges = Object.keys(added).length > 0 ||
-        Object.keys(removed).length > 0 ||
-        Object.values(updated).some(([, to]: any) => {
-          const type = to.typeName;
-
-          if (type === 'shape' && event.source === 'user') {
-            return true;
-          }
-
-          if (type === 'camera') {
-            const cam = to;
-            const moved = cam.x !== lastCameraRef.current.x || cam.y !== lastCameraRef.current.y || cam.z !== lastCameraRef.current.z;
-            if (moved) {
-              lastCameraRef.current = { x: cam.x, y: cam.y, z: cam.z };
-              return true;
-            }
-          }
-
-          // Instance: We ignore this for auto-save as it triggers on every mouse move (cursor tracking)
-          // The 'camera' record above is sufficient for panning and zoom persistence.
-          return false;
-        });
-
-      if (hasRelevantChanges) {
-        handleSave();
-      }
-
-      Object.values(updated).forEach(([, to]: any) => {
-        if (to.type === 'text' || to.type === 'rich-text') {
-          // Log prop changes to trace alignment/style issues
-          // console.log(`[${new Date().toISOString()}] [EditorUpdate] Text updated:`, to.id, to.props);
-        }
-      });
-    });
-
-    return () => {
-      cleanup();
-      // If we have unsaved changes when the component or pageId changes, trigger one last save
-      if (hasUnsavedChangesRef.current) {
-        save();
-      }
-      clearTimeout(timeout);
-    };
-  }, [editor, pageId, sidebarColumns]);
-
-  // Derived Active Tool State (Reactive via track)
-  const currentToolId = editor.getCurrentToolId();
+  // Derived Active Tool State
   const editingShapeId = editor.getEditingShapeId();
   const editingShape = editingShapeId ? editor.getShape(editingShapeId) : null;
   const isEmulatedTextTool = editingShape && (editingShape.type === 'text' || editingShape.type === 'rich-text');
+  const currentToolId = editor.getCurrentToolId();
 
   const activeTool = (() => {
-    // 1. Force override (Creation/Switching/Intent)
     if (forceTextModeRef.current || isLockingUI) return 'text';
-
-    // 2. Real Text Editing
     if (isEmulatedTextTool) return 'text';
-
-    // 3. User intentional Sticky Tool
     if (manualTool === 'text' && currentToolId === 'select') return 'text';
     if (manualTool === 'shapes' && currentToolId === 'select') return 'shapes';
-
-    // 4. Fallback to real tool (handling geo, arrow, line as 'shapes')
-    if (currentToolId === 'geo' || currentToolId === 'arrow' || currentToolId === 'line') {
-      return 'shapes';
-    }
-
+    if (['geo', 'arrow', 'line'].includes(currentToolId)) return 'shapes';
     return currentToolId;
   })();
 
-  // Sync isLockingUI back to Ref for non-reactive handlers
   useEffect(() => {
     forceTextModeRef.current = isLockingUI;
-
-    // Manage CSS class reactively
     if (parentRef.current) {
-      if (isLockingUI) {
-        parentRef.current.classList.add(styles.hideSelection);
-      } else {
-        parentRef.current.classList.remove(styles.hideSelection);
-      }
+      parentRef.current.classList.toggle(styles.hideSelection, isLockingUI);
     }
   }, [isLockingUI, parentRef]);
 
-  // STICKY TOOL: If user intent is 'text' or 'shapes', push back from 'select' if idle
+  // Handle auto-unlock
   useEffect(() => {
-    // For shapes or text mode: Do not allow selection boxes after creating/editing
-    if ((manualTool === 'shapes' || manualTool === 'text') && !editingShapeId && editor.getSelectedShapeIds().length > 0) {
-      editor.selectNone();
-    }
-
-    if (currentToolId === 'select' && !editingShapeId && !isLockingUI && editor.getSelectedShapeIds().length === 0) {
-      if (manualTool === 'text') {
-        editor.setCurrentTool('text');
-      } else if (manualTool === 'shapes') {
-        const lastTool = lastGeoToolRef.current as any;
-        if (editor.getCurrentToolId() !== lastTool) {
-          editor.setCurrentTool(lastTool);
-        }
-      }
-    }
-  }, [currentToolId, editingShapeId, isLockingUI, editor, manualTool, editor.getSelectedShapeIds().length]);
-
-  // AUTO-UNLOCK: When editing starts, we can safely reveal the UI
-  useEffect(() => {
-    if (isEmulatedTextTool && isLockingUI) {
-      setIsLockingUI(false);
-    }
-  }, [isEmulatedTextTool, isLockingUI, editingShapeId]);
-
-  // --- Eraser Override Logic ---
-  useEffect(() => {
-    if (!editor) return;
-
-    const originalIsErasable = (editor as any).isShapeErasable ? (editor as any).isShapeErasable.bind(editor) : null;
-
-    // Try both new and old names just in case
-    (editor as any).isErasable = (shape: any) => {
-      if (editor.getCurrentToolId() === 'eraser') return shape.type === 'draw';
-      return originalIsErasable ? originalIsErasable(shape) : true;
-    };
-    (editor as any).isShapeErasable = (editor as any).isErasable;
-
-    return () => {
-      // Restore
-      if (editor) {
-        if (originalIsErasable) {
-          (editor as any).isErasable = originalIsErasable;
-          (editor as any).isShapeErasable = originalIsErasable;
-        } else {
-          delete (editor as any).isErasable;
-          delete (editor as any).isShapeErasable;
-        }
-      }
-    };
-  }, [editor]);
-
-  // --- Pen Mode Logic ---
-  useEffect(() => {
-    const container = parentRef.current;
-    if (!container) return;
-
-    // Track active touches to support multi-touch panning
-    const activeTouchIds = new Set<number>();
-    let previousTool: string | null = null;
-    let didSwitchToHand = false;
-
-    const handlePointerDown = (e: PointerEvent) => {
-      if (document.body.classList.contains('rename-overlay-active')) {
-        return;
-      }
-
-      const target = e.target as HTMLElement;
-      if (target.closest?.('[data-is-ui="true"]')) return;
-
-      const { penMode } = useFileSystemStore.getState();
-      const currentTool = editor.getCurrentToolId();
-
-      // Apple Pencil Eraser Detection (iPadOS 18+)
-      // buttons: 32 is eraser mode, buttons: 1 is normal mode
-      if (e.pointerType === 'pen') {
-        if (e.buttons === 32 || e.button === 5) {
-          if (currentTool !== 'eraser') {
-            syncLog(`✏️ [PENCIL] Eraser mode detected (buttons: ${e.buttons})`);
-            lastToolBeforeEraserRef.current = currentTool;
-            autoSwitchedEraserRef.current = true;
-            editor.setCurrentTool('eraser');
-          }
-        } else if (e.buttons === 1) {
-          if (autoSwitchedEraserRef.current && currentTool === 'eraser') {
-            syncLog(`✏️ [PENCIL] Normal mode restored (buttons: ${e.buttons})`);
-            const toolToRestore = lastToolBeforeEraserRef.current || 'draw';
-            editor.setCurrentTool(toolToRestore);
-            autoSwitchedEraserRef.current = false;
-            lastToolBeforeEraserRef.current = null;
-          }
-        }
-      }
-
-      // If Pen Mode is on, and we are drawing/erasing, and input is NOT pen
-      if (penMode && (currentTool === 'draw' || currentTool === 'eraser') && e.pointerType !== 'pen') {
-        // Switch to 'hand' tool for panning
-        if (activeTouchIds.size === 0) {
-          previousTool = currentTool;
-          editor.setCurrentTool('hand');
-          didSwitchToHand = true;
-        }
-        activeTouchIds.add(e.pointerId);
-        // Do NOT stop propagation - let Tldraw handle it as a Hand tool event
-      }
-    };
-
-    const handlePointerUp = (e: PointerEvent) => {
-      if (document.body.classList.contains('rename-overlay-active')) return;
-
-      const target = e.target as HTMLElement;
-      if (target.closest?.('[data-is-ui="true"]')) return;
-      console.log(`[CanvasArea] pointerup type=${e.pointerType} target=${target.tagName}#${target.id}.${target.className}`);
-      if (activeTouchIds.has(e.pointerId)) {
-        activeTouchIds.delete(e.pointerId);
-
-        // If all fingers lifted and we previously switched tool, restore it
-        if (activeTouchIds.size === 0 && didSwitchToHand) {
-          const toolToRestore = previousTool;
-          didSwitchToHand = false;
-          previousTool = null;
-
-          // Restore text/draw tool on next frame to safely exit hand mode
-          requestAnimationFrame(() => {
-            if (toolToRestore && editor) {
-              // Only restore if we are still in hand mode (user didn't change tool manually)
-              if (editor.getCurrentToolId() === 'hand') {
-                editor.setCurrentTool(toolToRestore);
-              }
-            }
-          });
-        }
-      }
-    };
-
-    // Use capture to intercept before Tldraw acts on it
-    container.addEventListener('pointerdown', handlePointerDown, { capture: true });
-    // Global up/cancel needed because drag can end outside canvas
-    window.addEventListener('pointerup', handlePointerUp, { capture: true });
-    window.addEventListener('pointercancel', handlePointerUp, { capture: true });
-
-    return () => {
-      container.removeEventListener('pointerdown', handlePointerDown, { capture: true });
-      window.removeEventListener('pointerup', handlePointerUp, { capture: true });
-      window.removeEventListener('pointercancel', handlePointerUp, { capture: true });
-    };
-  }, [editor, parentRef]);
-
-
-
-
-
-  // Force Tldraw internal theme
-  useEffect(() => {
-    editor.user.updateUserPreferences({ colorScheme: isDark ? 'dark' : 'light' });
-  }, [editor, isDark]);
-
-  // Sync Tldraw locale with app language
-  useEffect(() => {
-    editor.user.updateUserPreferences({ locale: i18n.language });
-  }, [editor, i18n.language]);
-
-  // --- Interaction Engine ---
-  useEffect(() => {
-    const container = editor.getContainer();
-    if (!container) return;
-
-    // 1. Pointer Down (Text Logic)
-    const handlePointerDownCapture = (e: PointerEvent) => {
-      // Ignore clicks on UI elements (Toolbar, Bubble, etc.)
-      const target = e.target as HTMLElement;
-      if (target.closest('[data-is-ui="true"]')) return;
-
-      // Allow panning with middle/right click (ignore if not left click)
-      if (e.button !== 0) return;
-
-      const toolId = editor.getCurrentToolId();
-      if (toolId !== 'text') return;
-
-      const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
-      const shape = editor.getShapeAtPoint(p);
-
-      // A. Click on Existing Text -> Focus Edit
-      if (shape && (shape.type === 'text' || shape.type === 'rich-text')) {
-        if (editor.getEditingShapeId() === shape.id) {
-          return; // Already editing, let browser handle cursor position
-        }
-
-        // Switching from select or another edit
-        // LOCK UI: Prevent flicker to 'select' mode
-        setIsLockingUI(true);
-
-        // Batch operations to prevent intermediate render of "Selection Box"
-        transact(() => {
-          // Explicitly set tool back to 'text' and start editing
-          editor.setCurrentTool('text');
-          editor.setEditingShape(shape.id);
-        });
-
-        // Do NOT stop propagation here to allow the browser to place the text cursor
-        return;
-      }
-
-      // B. Click on Empty OR Non-text object -> Create (Wait for Drag decision)
-      e.stopPropagation();
-
-      const id = createShapeId();
-      const startX = p.x;
-      const startY = p.y;
-
-      // Initial: Auto Size (Click default)
-      const currentPrefs = useUserPreferencesStore.getState();
-
-      editor.createShape({
-        id,
-        type: 'rich-text',
-        x: startX,
-        y: startY,
-        props: {
-          html: '',
-          autoSize: true, // Auto by default
-          w: 200, h: 50,
-          isCreating: true, // Show dashed border
-          // Inject saved configuration
-          color: currentPrefs.textColor,
-          size: currentPrefs.textSize,
-          font: currentPrefs.textFont,
-          align: currentPrefs.textAlign,
-          bold: currentPrefs.textBold,
-          italic: currentPrefs.textItalic,
-          underline: currentPrefs.textUnderline,
-          strike: currentPrefs.textStrike
-        }
-      });
-
-      editor.select(id);
-
-      if (parentRef.current) parentRef.current.classList.add(styles.hideSelection);
-
-      const onPointerMove = (moveEvent: PointerEvent) => {
-        const curr = editor.screenToPage({ x: moveEvent.clientX, y: moveEvent.clientY });
-        const dist = Math.hypot(curr.x - startX, curr.y - startY);
-
-        if (dist > 5) {
-          // Dragging -> Switch to Fixed Mode
-          const w = Math.max(50, curr.x - startX);
-          const h = Math.max(30, curr.y - startY);
-          editor.updateShape({ id, type: 'rich-text', props: { w, h, autoSize: false } });
-        }
-      };
-
-      const onPointerUp = () => {
-        window.removeEventListener('pointermove', onPointerMove);
-        window.removeEventListener('pointerup', onPointerUp);
-
-        // LOCK UI for transition
-        setIsLockingUI(true);
-        if (parentRef.current) parentRef.current.classList.add(styles.hideSelection);
-
-        transact(() => {
-          editor.updateShape({ id, type: 'rich-text', props: { isCreating: false } });
-          editor.setCurrentTool('text'); // Stay in text mode
-          editor.select(id);
-          editor.setEditingShape(id);
-        });
-
-        // The useEffect will handle the unlock once editing starts
-      };
-
-      window.addEventListener('pointermove', onPointerMove);
-      window.addEventListener('pointerup', onPointerUp);
-    };
-
-    // 2. Double Click (Select -> Text Edit)
-    const handleDoubleClick = (e: MouseEvent) => {
-      const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
-      const shape = editor.getShapeAtPoint(p);
-      if (shape && (shape.type === 'rich-text' || shape.type === 'text')) {
-        console.log(`[${new Date().toISOString()}] [Click] DoubleClick on:`, shape.id);
-        // If we double click a text, we enter edit mode. 
-        editor.setEditingShape(shape.id);
-      }
-    };
-
-
-
-    container.addEventListener('pointerdown', handlePointerDownCapture, { capture: true });
-
-    container.addEventListener('dblclick', handleDoubleClick);
-
-    return () => {
-      container.removeEventListener('pointerdown', handlePointerDownCapture, { capture: true });
-
-      container.removeEventListener('dblclick', handleDoubleClick);
-    };
-  }, [editor]);
-
-  // 3. Pro Interaction: Entering Text tool while a text shape is selected -> Start Editing
-  useEffect(() => {
-    const handleToolChange = () => {
-      if (editor.getCurrentToolId() === 'text') {
-        const selectedIds = editor.getSelectedShapeIds();
-        if (selectedIds.length === 1) {
-          const shape = editor.getShape(selectedIds[0]);
-          if (shape && (shape.type === 'text' || shape.type === 'rich-text')) {
-            // Already selected -> Enter edit mode immediately
-            if (editor.getEditingShapeId() !== shape.id) {
-              editor.setEditingShape(shape.id);
-            }
-          }
-        }
-      }
-    };
-
-    // We can use the store listen or a simple effect on currentToolId
-    const toolId = editor.getCurrentToolId();
-    if (toolId === 'text') {
-      handleToolChange();
-    }
-  }, [editor.getCurrentToolId()]);
-
-
-  // Interaction state
-  const isPanningRef = useRef(false);
-  const isZoomingRef = useRef(false);
-  const lastPointRef = useRef({ x: 0, y: 0 });
-  const startPanningPointRef = useRef({ x: 0, y: 0 });
-  const startPanningCameraRef = useRef({ x: 0, y: 0, z: 1 });
-  // We'll store the previous tool to restore it after Space panning
-  const previousToolRef = useRef('select');
-
-  // Apple Pencil Eraser detection
-  const lastToolBeforeEraserRef = useRef<string | null>(null);
-  const autoSwitchedEraserRef = useRef(false);
-
-  // --- Event Handlers ---
-  // --- Interaction Engine ---
-  useEffect(() => {
-    const container = editor.getContainer();
-    if (!container) return;
-
-    // Context menu is now handled by TLDraw's DefaultContextMenu component
-    // No custom handler needed
-
-    // Longpress detection for touch and pen
-    const LONGPRESS_DURATION = 600; // ms
-    const MOVEMENT_THRESHOLD = 10; // px
-    let longpressTimer: number | null = null;
-    let longpressStart: { x: number; y: number; target: EventTarget | null } | null = null;
-
-    const handlePointerDownForLongpress = (e: PointerEvent) => {
-      // Only for touch and pen in selection mode
-      const currentTool = editor.getCurrentToolId();
-      const isEditingText = !!editor.getEditingShapeId();
-
-      if ((e.pointerType === 'touch' || e.pointerType === 'pen') &&
-        currentTool === 'select' &&
-        !isEditingText &&
-        e.button === 0) {
-        longpressStart = { x: e.clientX, y: e.clientY, target: e.target };
-
-        longpressTimer = setTimeout(() => {
-          if (longpressStart) {
-            // Only use the blocker in PWA standalone mode
-            const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
-              (window.navigator as any).standalone ||
-              document.referrer.includes('android-app://');
-
-            if (isStandalone) {
-              // Create a visual blocker div to intercept trailing events
-              const blocker = document.createElement('div');
-              blocker.style.position = 'fixed';
-              blocker.style.inset = '0';
-              blocker.style.zIndex = '100000';
-              blocker.style.backgroundColor = 'transparent';
-              blocker.style.pointerEvents = 'auto';
-              blocker.style.touchAction = 'none';
-
-              let isRemoving = false;
-              const cleanup = () => {
-                if (blocker.parentNode) {
-                  document.body.removeChild(blocker);
-                }
-                window.removeEventListener('pointerdown', handleEvent, { capture: true });
-                window.removeEventListener('pointerup', handleEvent, { capture: true });
-                window.removeEventListener('touchend', handleEvent, { capture: true });
-                window.removeEventListener('click', handleEvent, { capture: true });
-                window.removeEventListener('contextmenu', handleEvent, { capture: true });
-              };
-
-              const handleEvent = (e: any) => {
-                const x = e.clientX ?? e.touches?.[0]?.clientX ?? 0;
-                const y = e.clientY ?? e.touches?.[0]?.clientY ?? 0;
-
-                // If we are waiting to remove (finger already lifted) and user clicks somewhere else (likely the menu)
-                if ((e.type === 'pointerdown' || e.type === 'touchstart') && isRemoving) {
-                  const dist = Math.hypot(x - longpressStart!.x, y - longpressStart!.y);
-                  if (dist > 40) {
-                    cleanup();
-                    return; // Let this interaction pass to Tldraw
-                  }
-                }
-
-                // Otherwise, block everything
-                e.preventDefault();
-                e.stopImmediatePropagation();
-
-                if (e.type === 'pointerup' || e.type === 'touchend' || e.type === 'click') {
-                  if (!isRemoving) {
-                    isRemoving = true;
-                    // Safety cleanup if user never interacts again
-                    setTimeout(cleanup, 250);
-                  }
-                }
-              };
-
-              // Capture phase on window to intercept BEFORE Tldraw 
-              window.addEventListener('pointerdown', handleEvent, { capture: true });
-              window.addEventListener('pointerup', handleEvent, { capture: true });
-              window.addEventListener('touchend', handleEvent, { capture: true });
-              window.addEventListener('click', handleEvent, { capture: true });
-              window.addEventListener('contextmenu', handleEvent, { capture: true });
-
-              document.body.appendChild(blocker);
-            }
-
-            // Trigger context menu at pointer position
-            const contextMenuEvent = new MouseEvent('contextmenu', {
-              bubbles: true,
-              cancelable: true,
-              clientX: longpressStart.x,
-              clientY: longpressStart.y,
-            });
-            longpressStart.target?.dispatchEvent(contextMenuEvent);
-            longpressStart = null;
-          }
-        }, LONGPRESS_DURATION);
-      }
-    };
-
-    const handlePointerMoveForLongpress = (e: PointerEvent) => {
-      if (longpressStart && longpressTimer) {
-        const distance = Math.hypot(
-          e.clientX - longpressStart.x,
-          e.clientY - longpressStart.y
-        );
-
-        if (distance > MOVEMENT_THRESHOLD) {
-          clearTimeout(longpressTimer);
-          longpressTimer = null;
-          longpressStart = null;
-        }
-      }
-    };
-
-    const handlePointerUpForLongpress = () => {
-      if (longpressTimer) {
-        clearTimeout(longpressTimer);
-        longpressTimer = null;
-        longpressStart = null;
-      }
-    };
-
-    const handlePointerDown = (e: PointerEvent) => {
-      // Ignore clicks on UI elements (toolbar, bubble, etc)
-      if ((e.target as HTMLElement).closest('[data-is-ui="true"]')) return;
-
-      // SHAPES STRICT TOOL: Ensure we are in a drawing tool when clicking
-      if (manualTool === 'shapes' && e.button === 0) {
-        const currentMode = editor.getCurrentToolId();
-        if (currentMode === 'select') {
-          editor.setCurrentTool(lastGeoToolRef.current as any);
-        }
-      }
-
-      // Only middle mouse button for panning (button 1)
-      // Right-click (button 2) is now reserved for context menu
-      if (e.button === 1) {
-        isPanningRef.current = true;
-        startPanningPointRef.current = { x: e.clientX, y: e.clientY };
-        startPanningCameraRef.current = editor.getCamera();
-        container.setPointerCapture(e.pointerId);
-        e.preventDefault();
-        return;
-      }
-      if (e.button === 0 && e.ctrlKey) {
-        isZoomingRef.current = true;
-        lastPointRef.current = { x: e.clientX, y: e.clientY };
-        container.setPointerCapture(e.pointerId);
-        e.preventDefault();
-        return;
-      }
-    };
-
-    const handlePointerMove = (e: PointerEvent) => {
-      if (isPanningRef.current) {
-        const deltaX = e.clientX - startPanningPointRef.current.x;
-        const deltaY = e.clientY - startPanningPointRef.current.y;
-
-        const { x, y, z } = startPanningCameraRef.current;
-        // Panning 1:1 - add total delta divided by initial zoom to get follow-mouse behavior
-        editor.setCamera({ x: x + deltaX / z, y: y + deltaY / z, z });
-        return;
-      }
-      if (isZoomingRef.current) {
-        const deltaY = e.clientY - lastPointRef.current.y;
-        lastPointRef.current = { x: e.clientX, y: e.clientY };
-        const zoomRate = 0.01;
-        const { z } = editor.getCamera();
-        const factor = 1 - deltaY * zoomRate;
-        const newZoom = Math.max(0.1, Math.min(5, z * factor));
-        const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
-        const rect = container.getBoundingClientRect();
-        const localX = e.clientX - rect.left;
-        const localY = e.clientY - rect.top;
-        const newX = (localX / newZoom) - p.x;
-        const newY = (localY / newZoom) - p.y;
-        editor.setCamera({ x: newX, y: newY, z: newZoom });
-        return;
-      }
-    };
-
-    const handlePointerUp = (e: PointerEvent) => {
-      if (isPanningRef.current || isZoomingRef.current) {
-        isPanningRef.current = false;
-        isZoomingRef.current = false;
-        try { container.releasePointerCapture(e.pointerId); } catch (err) { }
-      }
-    };
-
-    const handleWheel = (e: WheelEvent) => {
-      if (e.ctrlKey) return;
-      e.preventDefault();
-      e.stopPropagation();
-      const { clientX, clientY, deltaY } = e;
-      const { z } = editor.getCamera();
-      const zoomDetails = 0.001;
-      const factor = 1 - deltaY * zoomDetails;
-      const safeFactor = Math.max(0.1, Math.min(8, z * factor));
-      const p = editor.screenToPage({ x: clientX, y: clientY });
-      const rect = container.getBoundingClientRect();
-      const localX = clientX - rect.left;
-      const localY = clientY - rect.top;
-      const newX = (localX / safeFactor) - p.x;
-      const newY = (localY / safeFactor) - p.y;
-      editor.setCamera({ x: newX, y: newY, z: safeFactor });
-    };
-
-    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
-      const activeEl = document.activeElement;
-      const isInput = activeEl?.tagName === 'INPUT' || activeEl?.tagName === 'TEXTAREA';
-      const isEditingText = activeEl && 'isContentEditable' in activeEl && (activeEl as HTMLElement).isContentEditable;
-      if (isInput || isEditingText) return;
-
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        const isEditingShape = !!editor.getEditingShapeId();
-        if (isEditingShape || isInput || isEditingText) return;
-        const selectedIds = editor.getSelectedShapeIds();
-        if (selectedIds.length > 0) {
-          editor.deleteShapes(selectedIds);
-          e.preventDefault();
-        }
-        return;
-      }
-
-      // Undo/Redo
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
-        if (e.shiftKey) {
-          editor.redo();
-        } else {
-          editor.undo();
-        }
-        e.preventDefault();
-        return;
-      }
-
-      // Redo (Alternative)
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y') {
-        editor.redo();
-        e.preventDefault();
-        return;
-      }
-
-      if (e.code === 'Space' && !e.repeat && !e.ctrlKey && !e.shiftKey && !e.altKey && editor.getCurrentToolId() !== 'hand') {
-        previousToolRef.current = editor.getCurrentToolId();
-        editor.setCurrentTool('hand');
-      }
-    };
-
-    const handleKeyUp = (e: globalThis.KeyboardEvent) => {
-      if (e.code === 'Space' && editor.getCurrentToolId() === 'hand') {
-        editor.setCurrentTool(previousToolRef.current);
-      }
-    };
-
-    container.addEventListener('pointerdown', handlePointerDown, { capture: true });
-    container.addEventListener('pointermove', handlePointerMove);
-    container.addEventListener('pointerup', handlePointerUp);
-    container.addEventListener('wheel', handleWheel, { passive: false, capture: true });
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
-
-    // Longpress event listeners for touch and pen
-    container.addEventListener('pointerdown', handlePointerDownForLongpress);
-    container.addEventListener('pointermove', handlePointerMoveForLongpress);
-    container.addEventListener('pointerup', handlePointerUpForLongpress);
-    container.addEventListener('pointercancel', handlePointerUpForLongpress);
-
-
-    // --- Gesture Detection (2/3 Finger Tap) ---
-    let touchStartTime = 0;
-    let initialTouches: { id: number, x: number, y: number }[] = [];
-    let touchMoving = false;
-
-    const handleTouchStart = (e: TouchEvent) => {
-      // Ignore if it's already a complex gesture or we are in tool mode that might conflict
-      if (e.touches.length === 2 || e.touches.length === 3) {
-        touchStartTime = Date.now();
-        touchMoving = false;
-        initialTouches = Array.from(e.touches).map(t => ({ id: t.identifier, x: t.clientX, y: t.clientY }));
-      } else {
-        initialTouches = [];
-      }
-    };
-
-    const handleTouchMove = (e: TouchEvent) => {
-      if (initialTouches.length > 0) {
-        for (let i = 0; i < e.touches.length; i++) {
-          const t = e.touches[i];
-          const initial = initialTouches.find(it => it.id === t.identifier);
-          if (initial) {
-            const dist = Math.hypot(t.clientX - initial.x, t.clientY - initial.y);
-            if (dist > 10) { // Movement threshold
-              touchMoving = true;
-              break;
-            }
-          }
-        }
-      }
-    };
-
-    const handleTouchEnd = (e: TouchEvent) => {
-      if (initialTouches.length > 0 && e.touches.length === 0) {
-        const duration = Date.now() - touchStartTime;
-        if (duration < 300 && !touchMoving) {
-          if (initialTouches.length === 2) {
-            editor.undo();
-          } else if (initialTouches.length === 3) {
-            editor.redo();
-          }
-        }
-        initialTouches = [];
-      }
-    };
-
-    container.addEventListener('touchstart', handleTouchStart, { passive: true });
-    container.addEventListener('touchmove', handleTouchMove, { passive: true });
-    container.addEventListener('touchend', handleTouchEnd, { passive: true });
-
-    return () => {
-      container.removeEventListener('pointerdown', handlePointerDown, { capture: true });
-      container.removeEventListener('pointermove', handlePointerMove);
-      container.removeEventListener('pointerup', handlePointerUp);
-      container.removeEventListener('wheel', handleWheel, { capture: true } as any);
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
-
-      // Cleanup longpress event listeners
-      container.removeEventListener('pointerdown', handlePointerDownForLongpress);
-      container.removeEventListener('pointermove', handlePointerMoveForLongpress);
-      container.removeEventListener('pointerup', handlePointerUpForLongpress);
-      container.removeEventListener('pointercancel', handlePointerUpForLongpress);
-
-      // Clear any pending longpress timer
-      if (longpressTimer) {
-        clearTimeout(longpressTimer);
-      }
-
-      container.removeEventListener('touchstart', handleTouchStart);
-      container.removeEventListener('touchmove', handleTouchMove);
-      container.removeEventListener('touchend', handleTouchEnd);
-    };
-  }, [editor, manualTool]);
-
-  // --- Sidebar Panning Transition ---
-  const lastSidebarColumnsRef = useRef(sidebarColumns);
-  useEffect(() => {
-    if (lastSidebarColumnsRef.current === sidebarColumns) return;
-
-    const columnWidth = 250;
-    const margin = 12;
-    const prevWidth = lastSidebarColumnsRef.current > 0 ? (columnWidth * lastSidebarColumnsRef.current + margin * 2) : 0;
-    const currWidth = sidebarColumns > 0 ? (columnWidth * sidebarColumns + margin * 2) : 0;
-    const diff = currWidth - prevWidth;
-
-    const { x, y, z } = editor.getCamera();
-    // Shift camera by half the diff / zoom to keep content centered in the remaining visible space
-    // If sidebar on RIGHT expands, shift camera to the LEFT (invert diff)
-    const shiftX = leftHandedMode ? -diff : diff;
-    editor.setCamera({ x: x + (shiftX / 2) / z, y, z }, { animation: { duration: 300 } });
-
-    lastSidebarColumnsRef.current = sidebarColumns;
-  }, [editor, sidebarColumns]);
-
-  // Dash Style Memory
-  const lastShapesDashRef = useRef<string>('solid');
-  const lastPencilDashRef = useRef<string>('draw');
-  const lastGeoToolRef = useRef<string>('geo');
-
-  useEffect(() => {
-    // Sync memory with current editor state when styles change
-    const unlisten = editor.store.listen(() => {
-      const currentDash = editor.getStyleForNextShape(DefaultDashStyle) as string;
-      const currentTool = editor.getCurrentToolId();
-      if (currentTool === 'geo' || currentTool === 'arrow' || currentTool === 'line' || currentTool === 'note') {
-        lastShapesDashRef.current = currentDash;
-        if (currentTool !== 'note') lastGeoToolRef.current = currentTool;
-      } else if (currentTool === 'draw') {
-        lastPencilDashRef.current = currentDash;
-      }
-    }, { source: 'user', scope: 'session' });
-    return () => unlisten();
-  }, [editor]);
+    if (isEmulatedTextTool && isLockingUI) setIsLockingUI(false);
+  }, [isEmulatedTextTool, isLockingUI]);
 
   const handleSelectTool = (tool: string) => {
     setManualTool(tool);
+    if (['draw', 'eraser'].includes(tool)) editor.selectNone();
+    editor.setEditingShape(null);
 
-    // Deselect all when switching to drawing tools
-    if (tool === 'draw' || tool === 'eraser') {
-      editor.selectNone();
-    }
-
-    editor.setEditingShape(null); // Exit edit mode first
-
-    // Handle special cases before setting the tool
     if (tool === 'shapes') {
       editor.setCurrentTool(lastGeoToolRef.current as any);
-      editor.setStyleForNextShapes(DefaultDashStyle, lastShapesDashRef.current);
     } else if (tool.startsWith('geo-')) {
       editor.setCurrentTool(tool);
-      editor.setStyleForNextShapes(DefaultDashStyle, lastShapesDashRef.current);
-    } else if (tool === 'draw') {
-      editor.setCurrentTool(tool);
-      // Restore last pencil dash (defaults to draw/irregular)
-      editor.setStyleForNextShapes(DefaultDashStyle, lastPencilDashRef.current);
     } else {
-      // Normal tool activation
       editor.setCurrentTool(tool);
-    }
-
-    if (tool === 'text') {
-      // Re-apply styles...
-      editor.setStyleForNextShapes(DefaultColorStyle, userPrefs.textColor);
-      editor.setStyleForNextShapes(DefaultSizeStyle, userPrefs.textSize);
-      editor.setStyleForNextShapes(DefaultFontStyle, userPrefs.textFont);
-      const validAlign = userPrefs.textAlign === 'justify' ? 'start' : userPrefs.textAlign;
-      editor.setStyleForNextShapes(DefaultTextAlignStyle, validAlign as any);
     }
   };
 
@@ -1215,90 +121,25 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
     <div className={styles.canvasContainer}>
       <DebugOverlay sidebarColumns={sidebarColumns} />
       <CenterMark />
-      {!isSidebarOpen && (
-        <UIPortal>
-          <div
-            className={styles.topBar}
-            style={{
-              '--topbar-left': leftHandedMode ? 'auto' : '1rem',
-              '--topbar-right': leftHandedMode ? '1rem' : 'auto',
-            } as React.CSSProperties}
-          >
-            <button className={styles.iconButton} onClick={toggleSidebar}>
-              {leftHandedMode ? <PanelRightOpen size={20} /> : <PanelLeftOpen size={20} />}
-            </button>
-          </div>
-          <CanvasTitle />
-        </UIPortal>
-      )}
-
       <Toolbar
         activeTool={activeTool}
         onSelectTool={handleSelectTool}
         onUpload={(files) => {
           const center = editor.getViewportPageBounds().center;
-          editor.putExternalContent({
-            type: 'files',
-            files,
-            point: center
-          });
+          editor.putExternalContent({ type: 'files', files, point: center });
         }}
         onAddUrl={(url) => {
           const center = editor.getViewportPageBounds().center;
-          editor.putExternalContent({
-            type: 'url',
-            url,
-            point: center
-          });
+          editor.putExternalContent({ type: 'url', url, point: center });
         }}
       />
       <Bubble activeTool={activeTool} />
-
       <HistoryControls sidebarColumns={sidebarColumns} leftHandedMode={leftHandedMode} />
-
       <CircularButton
         onPointerDown={(e) => e.stopPropagation()}
         onPointerUp={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          // Simple debounce to prevent single click action on double click? 
-          // For now, let's allow both or assume user intent. 
-          // Actually, Tldraw might be grabbing focus.
-          if (editor) {
-            const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-            const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
-            const viewportHalfHeight = window.innerHeight / 2;
-            const { z } = editor.getCamera();
-            editor.setCamera({ x: viewportCenter / z, y: viewportHalfHeight / z, z }, { animation: { duration: 300 } });
-          }
-        }}
-        onDoubleClick={(e) => {
-          e.stopPropagation();
-          const bounds = editor.getCurrentPageBounds();
-          if (!bounds) return;
-
-          const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
-          const padding = 64;
-          const availableWidth = window.innerWidth - sidebarWidth - padding;
-          const availableHeight = window.innerHeight - padding;
-
-          if (availableWidth <= 0 || availableHeight <= 0) return;
-
-          // Calculate ideal zoom (clamped to max 1 for clarity)
-          const zoomX = availableWidth / bounds.w;
-          const zoomY = availableHeight / bounds.h;
-          const z = Math.min(zoomX, zoomY, 1);
-
-          // Target screen center (offset by sidebar)
-          const targetX = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : sidebarWidth + (window.innerWidth - sidebarWidth) / 2;
-          const targetY = window.innerHeight / 2;
-
-          // camera.x = target_screen_x / zoom - target_page_x
-          const camX = (targetX / z) - (bounds.x + bounds.w / 2);
-          const camY = (targetY / z) - (bounds.y + bounds.h / 2);
-
-          editor.setCamera({ x: camX, y: camY, z }, { animation: { duration: 300 } });
-        }}
+        onClick={(e) => { e.stopPropagation(); handleRecenter(); }}
+        onDoubleClick={(e) => { e.stopPropagation(); handleRecenterAll(); }}
         title={t('recenter')}
         icon={<LocateFixed size={20} />}
         className={styles.recenterButton}
@@ -1312,69 +153,27 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, is
 });
 
 export const CanvasArea = () => {
-  const { t } = useTranslation();
   const { activePageId, isSidebarOpen, toggleSidebar, theme, pages, activePath, activeNotebookId, dominantHand } = useFileSystemStore();
   const leftHandedMode = dominantHand === 'left';
   const parentRef = useRef<HTMLDivElement>(null);
-
   const isDark = getIsDarkMode(theme);
 
-  const currentVersion = activePageId ? (pages[activePageId]?.version || 0) : 0;
-  const lastModifier = activePageId ? pages[activePageId]?.lastModifier : undefined;
-  const clientId = useSyncStore.getState().clientId;
-
-  // Show empty state when no page is selected
   if (!activePageId) {
-    const sidebarColumns = isSidebarOpen ? (activeNotebookId ? activePath.length + 2 : 1) : 0;
-    const sidebarWidth = sidebarColumns > 0 ? (sidebarColumns * 250 + 24) : 0;
-
     return (
-      <div className={styles.wrapper} style={{ '--sidebar-columns': sidebarColumns } as React.CSSProperties}>
-        {!isSidebarOpen && (
-          <UIPortal>
-            <div
-              className={styles.topBar}
-              style={{
-                '--topbar-left': leftHandedMode ? 'auto' : '1rem',
-                '--topbar-right': leftHandedMode ? '1rem' : 'auto',
-              } as React.CSSProperties}
-            >
-              <button className={styles.iconButton} onClick={toggleSidebar}>
-                {leftHandedMode ? <PanelRightOpen size={20} /> : <PanelLeftOpen size={20} />}
-              </button>
-            </div>
-            <CanvasTitle />
-          </UIPortal>
-        )}
-        <div
-          className={styles.welcomeScreen}
-          data-dominant-hand={dominantHand}
-          style={{
-            [leftHandedMode ? 'paddingRight' : 'paddingLeft']: `${sidebarWidth}px`,
-          }}>
-          <div className={styles.welcomeContent}>
-            <div className={styles.welcomeBranding}>
-              <h1>Cuaderno</h1>
-            </div>
-            <div className={styles.welcomeDescription}>
-              <p>
-                {t('welcome_description')}
-              </p>
-            </div>
-            <nav className={styles.welcomeNav}>
-              <a href="/cuaderno/privacy.html">{t('privacy_policy')}</a>
-              <a href="/cuaderno/terms.html">{t('terms_of_service')}</a>
-            </nav>
-            <div className={styles.welcomeInstruction}>
-              {t('select_page_to_start')}
-            </div>
-          </div>
-        </div>
-      </div>
+      <WelcomeScreen
+        isSidebarOpen={isSidebarOpen}
+        activeNotebookId={activeNotebookId}
+        activePath={activePath}
+        dominantHand={dominantHand}
+        toggleSidebar={toggleSidebar}
+      />
     );
   }
 
   const sidebarColumns = isSidebarOpen ? (activeNotebookId ? activePath.length + 2 : 1) : 0;
+  const currentVersion = activePageId ? (pages[activePageId]?.version || 0) : 0;
+  const lastModifier = activePageId ? pages[activePageId]?.lastModifier : undefined;
+  const clientId = useSyncStore.getState().clientId;
 
   return (
     <div className={styles.wrapper} ref={parentRef} style={{ '--sidebar-columns': sidebarColumns } as React.CSSProperties}>
@@ -1384,12 +183,9 @@ export const CanvasArea = () => {
         shapeUtils={customShapeUtils}
         licenseKey={import.meta.env.VITE_TLDRAW_LICENSE}
         options={{ maxPages: 1 }}
-        components={{
-          ContextMenu: DefaultContextMenu,
-        }}
+        components={{ ContextMenu: DefaultContextMenu }}
         overrides={{
           actions(_editor, actions) {
-            // Remove the "move-to-page" action if it still exists
             delete actions['move-to-page'];
             delete actions['context-menu.move-to-page'];
             return actions;

--- a/src/components/Canvas/CenterMark.tsx
+++ b/src/components/Canvas/CenterMark.tsx
@@ -1,0 +1,33 @@
+import { useEditor, track } from 'tldraw';
+
+export const CenterMark = track(() => {
+  const isDebug = new URLSearchParams(window.location.search).get('debug') === 'true';
+  if (!isDebug) return null;
+
+  const editor = useEditor();
+  const screenPoint = editor.pageToScreen({ x: 0, y: 0 });
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: screenPoint.x,
+        top: screenPoint.y,
+        transform: 'translate(-50%, -50%)',
+        pointerEvents: 'none',
+        zIndex: 999,
+        opacity: 0.8,
+        color: '#ff0000',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <line x1="12" y1="4" x2="12" y2="20" />
+        <line x1="4" y1="12" x2="20" y2="12" />
+        <circle cx="12" cy="12" r="3" fill="currentColor" />
+      </svg>
+    </div>
+  );
+});

--- a/src/components/Canvas/DebugOverlay.tsx
+++ b/src/components/Canvas/DebugOverlay.tsx
@@ -1,0 +1,55 @@
+import { useEditor, track } from 'tldraw';
+import { useState, useEffect } from 'react';
+
+export const DebugOverlay = track(({ sidebarColumns }: { sidebarColumns: number }) => {
+  const isDebug = new URLSearchParams(window.location.search).get('debug') === 'true';
+  if (!isDebug) return null;
+
+  const editor = useEditor();
+  const { x, y, z } = editor.getCamera();
+  const [screen, setScreen] = useState({ w: window.innerWidth, h: window.innerHeight });
+
+  useEffect(() => {
+    const handleResize = () => setScreen({ w: window.innerWidth, h: window.innerHeight });
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const columnWidth = 250;
+  const margin = 12;
+  const sidebarWidth = sidebarColumns > 0 ? (columnWidth * sidebarColumns + margin * 2) : 0;
+  const viewportCenter = (screen.w + sidebarWidth) / 2;
+
+  // Normalized X: 0 means perfectly centered in the available space
+  const normalizedX = x - (viewportCenter / z);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '1rem',
+        right: '4.5rem',
+        zIndex: 1000,
+        background: 'var(--glass-bg)',
+        backdropFilter: 'blur(var(--glass-blur))',
+        WebkitBackdropFilter: 'blur(var(--glass-blur))',
+        padding: '0.4rem 0.8rem',
+        borderRadius: 'var(--radius-md)',
+        border: '1px solid var(--glass-border)',
+        fontSize: '11px',
+        color: 'hsl(var(--color-text-secondary))',
+        fontFamily: 'monospace',
+        pointerEvents: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2px',
+        boxShadow: 'var(--shadow-md)'
+      }}
+    >
+      <div title="Actual Camera">CAM: {x.toFixed(0)}, {y.toFixed(0)}, {z.toFixed(2)}</div>
+      <div title="Normalized (Universal) Camera" style={{ color: 'var(--color-accent)' }}>NORM: {normalizedX.toFixed(0)}</div>
+      <div>WIN: {screen.w}x{screen.h}</div>
+      <div>SIDE: {sidebarWidth}px</div>
+    </div>
+  );
+});

--- a/src/components/Canvas/HistoryControls.tsx
+++ b/src/components/Canvas/HistoryControls.tsx
@@ -1,0 +1,41 @@
+import { useEditor, track } from 'tldraw';
+import { useTranslation } from 'react-i18next';
+import { Undo2, Redo2 } from 'lucide-react';
+import { CircularButton } from '../UI/CircularButton';
+import styles from './CanvasArea.module.css';
+import clsx from 'clsx';
+
+export const HistoryControls = track(({ sidebarColumns, leftHandedMode }: { sidebarColumns: number, leftHandedMode: boolean }) => {
+  const editor = useEditor();
+  const { t } = useTranslation();
+
+  const canUndo = editor.getCanUndo();
+  const canRedo = editor.getCanRedo();
+
+  const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+
+  return (
+    <div
+      className={styles.historyControls}
+      style={{
+        [leftHandedMode ? 'right' : 'left']: `calc(${sidebarWidth}px + 1rem)`,
+        [leftHandedMode ? 'left' : 'right']: 'auto'
+      } as React.CSSProperties}
+    >
+      <CircularButton
+        onClick={() => editor.undo()}
+        disabled={!canUndo}
+        title={t('undo')}
+        icon={<Undo2 size={20} />}
+        className={clsx(styles.historyButton, !canUndo && styles.disabled)}
+      />
+      <CircularButton
+        onClick={() => editor.redo()}
+        disabled={!canRedo}
+        title={t('redo')}
+        icon={<Redo2 size={20} />}
+        className={clsx(styles.historyButton, !canRedo && styles.disabled)}
+      />
+    </div>
+  );
+});

--- a/src/components/Canvas/WelcomeScreen.tsx
+++ b/src/components/Canvas/WelcomeScreen.tsx
@@ -1,0 +1,71 @@
+import { useTranslation } from 'react-i18next';
+import { PanelLeftOpen, PanelRightOpen } from 'lucide-react';
+import { UIPortal } from '../UIPortal';
+import { CanvasTitle } from './CanvasTitle';
+import styles from './CanvasArea.module.css';
+
+interface WelcomeScreenProps {
+  isSidebarOpen: boolean;
+  activeNotebookId: string | null;
+  activePath: string[]; // Adjust typing if needed
+  dominantHand: 'left' | 'right';
+  toggleSidebar: () => void;
+}
+
+export const WelcomeScreen = ({
+  isSidebarOpen,
+  activeNotebookId,
+  activePath,
+  dominantHand,
+  toggleSidebar
+}: WelcomeScreenProps) => {
+  const { t } = useTranslation();
+  const leftHandedMode = dominantHand === 'left';
+  const sidebarColumns = isSidebarOpen ? (activeNotebookId ? activePath.length + 2 : 1) : 0;
+  const sidebarWidth = sidebarColumns > 0 ? (sidebarColumns * 250 + 24) : 0;
+
+  return (
+    <div className={styles.wrapper} style={{ '--sidebar-columns': sidebarColumns } as React.CSSProperties}>
+      {!isSidebarOpen && (
+        <UIPortal>
+          <div
+            className={styles.topBar}
+            style={{
+              '--topbar-left': leftHandedMode ? 'auto' : '1rem',
+              '--topbar-right': leftHandedMode ? '1rem' : 'auto',
+            } as React.CSSProperties}
+          >
+            <button className={styles.iconButton} onClick={toggleSidebar}>
+              {leftHandedMode ? <PanelRightOpen size={20} /> : <PanelLeftOpen size={20} />}
+            </button>
+          </div>
+          <CanvasTitle />
+        </UIPortal>
+      )}
+      <div
+        className={styles.welcomeScreen}
+        data-dominant-hand={dominantHand}
+        style={{
+          [leftHandedMode ? 'paddingRight' : 'paddingLeft']: `${sidebarWidth}px`,
+        }}>
+        <div className={styles.welcomeContent}>
+          <div className={styles.welcomeBranding}>
+            <h1>Cuaderno</h1>
+          </div>
+          <div className={styles.welcomeDescription}>
+            <p>
+              {t('welcome_description')}
+            </p>
+          </div>
+          <nav className={styles.welcomeNav}>
+            <a href="/cuaderno/privacy.html">{t('privacy_policy')}</a>
+            <a href="/cuaderno/terms.html">{t('terms_of_service')}</a>
+          </nav>
+          <div className={styles.welcomeInstruction}>
+            {t('select_page_to_start')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useCanvasInteractions.ts
+++ b/src/hooks/useCanvasInteractions.ts
@@ -1,0 +1,261 @@
+import { useEffect, useRef } from 'react';
+import { Editor, createShapeId, transact } from 'tldraw';
+import styles from '../components/Canvas/CanvasArea.module.css';
+
+export const useCanvasInteractions = (
+  editor: Editor,
+  parentRef: React.RefObject<HTMLDivElement | null>,
+  manualTool: string,
+  setIsLockingUI: (locking: boolean) => void,
+  userPrefs: any,
+  lastGeoToolRef: React.MutableRefObject<string>
+) => {
+  const isPanningRef = useRef(false);
+  const isZoomingRef = useRef(false);
+  const lastPointRef = useRef({ x: 0, y: 0 });
+  const startPanningPointRef = useRef({ x: 0, y: 0 });
+  const startPanningCameraRef = useRef({ x: 0, y: 0, z: 1 });
+  const previousToolRef = useRef('select');
+
+  useEffect(() => {
+    const container = editor.getContainer();
+    if (!container) return;
+
+    const handlePointerDownCapture = (e: PointerEvent) => {
+      if ((e.target as HTMLElement).closest('[data-is-ui="true"]')) return;
+      if (e.button !== 0) return;
+
+      const toolId = editor.getCurrentToolId();
+      if (toolId !== 'text') return;
+
+      const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
+      const shape = editor.getShapeAtPoint(p);
+
+      if (shape && (shape.type === 'text' || shape.type === 'rich-text')) {
+        if (editor.getEditingShapeId() === shape.id) return;
+        setIsLockingUI(true);
+        transact(() => {
+          editor.setCurrentTool('text');
+          editor.setEditingShape(shape.id);
+        });
+        return;
+      }
+
+      e.stopPropagation();
+      const id = createShapeId();
+      const startX = p.x;
+      const startY = p.y;
+
+      editor.createShape({
+        id,
+        type: 'rich-text',
+        x: startX,
+        y: startY,
+        props: {
+          html: '',
+          autoSize: true,
+          w: 200, h: 50,
+          isCreating: true,
+          color: userPrefs.textColor,
+          size: userPrefs.textSize,
+          font: userPrefs.textFont,
+          align: userPrefs.textAlign,
+          bold: userPrefs.textBold,
+          italic: userPrefs.textItalic,
+          underline: userPrefs.textUnderline,
+          strike: userPrefs.textStrike
+        }
+      });
+
+      editor.select(id);
+      if (parentRef.current) parentRef.current.classList.add(styles.hideSelection);
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        const curr = editor.screenToPage({ x: moveEvent.clientX, y: moveEvent.clientY });
+        const dist = Math.hypot(curr.x - startX, curr.y - startY);
+        if (dist > 5) {
+          const w = Math.max(50, curr.x - startX);
+          const h = Math.max(30, curr.y - startY);
+          editor.updateShape({ id, type: 'rich-text', props: { w, h, autoSize: false } });
+        }
+      };
+
+      const onPointerUp = () => {
+        window.removeEventListener('pointermove', onPointerMove);
+        window.removeEventListener('pointerup', onPointerUp);
+        setIsLockingUI(true);
+        if (parentRef.current) parentRef.current.classList.add(styles.hideSelection);
+        transact(() => {
+          editor.updateShape({ id, type: 'rich-text', props: { isCreating: false } });
+          editor.setCurrentTool('text');
+          editor.select(id);
+          editor.setEditingShape(id);
+        });
+      };
+
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', onPointerUp);
+    };
+
+    const handleDoubleClick = (e: MouseEvent) => {
+      const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
+      const shape = editor.getShapeAtPoint(p);
+      if (shape && (shape.type === 'rich-text' || shape.type === 'text')) {
+        editor.setEditingShape(shape.id);
+      }
+    };
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if ((e.target as HTMLElement).closest('[data-is-ui="true"]')) return;
+      if (manualTool === 'shapes' && e.button === 0 && editor.getCurrentToolId() === 'select') {
+        editor.setCurrentTool(lastGeoToolRef.current as any);
+      }
+      if (e.button === 1) {
+        isPanningRef.current = true;
+        startPanningPointRef.current = { x: e.clientX, y: e.clientY };
+        startPanningCameraRef.current = editor.getCamera();
+        container.setPointerCapture(e.pointerId);
+        e.preventDefault();
+        return;
+      }
+      if (e.button === 0 && e.ctrlKey) {
+        isZoomingRef.current = true;
+        lastPointRef.current = { x: e.clientX, y: e.clientY };
+        container.setPointerCapture(e.pointerId);
+        e.preventDefault();
+        return;
+      }
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (isPanningRef.current) {
+        const deltaX = e.clientX - startPanningPointRef.current.x;
+        const deltaY = e.clientY - startPanningPointRef.current.y;
+        const { x, y, z } = startPanningCameraRef.current;
+        editor.setCamera({ x: x + deltaX / z, y: y + deltaY / z, z });
+      } else if (isZoomingRef.current) {
+        const deltaY = e.clientY - lastPointRef.current.y;
+        lastPointRef.current = { x: e.clientX, y: e.clientY };
+        const { z } = editor.getCamera();
+        const factor = 1 - deltaY * 0.01;
+        const newZoom = Math.max(0.1, Math.min(5, z * factor));
+        const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
+        const rect = container.getBoundingClientRect();
+        const newX = ((e.clientX - rect.left) / newZoom) - p.x;
+        const newY = ((e.clientY - rect.top) / newZoom) - p.y;
+        editor.setCamera({ x: newX, y: newY, z: newZoom });
+      }
+    };
+
+    const handlePointerUp = (e: PointerEvent) => {
+      if (isPanningRef.current || isZoomingRef.current) {
+        isPanningRef.current = false;
+        isZoomingRef.current = false;
+        try { container.releasePointerCapture(e.pointerId); } catch (err) { }
+      }
+    };
+
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const { z } = editor.getCamera();
+      const factor = 1 - e.deltaY * 0.001;
+      const safeFactor = Math.max(0.1, Math.min(8, z * factor));
+      const p = editor.screenToPage({ x: e.clientX, y: e.clientY });
+      const rect = container.getBoundingClientRect();
+      const newX = ((e.clientX - rect.left) / safeFactor) - p.x;
+      const newY = ((e.clientY - rect.top) / safeFactor) - p.y;
+      editor.setCamera({ x: newX, y: newY, z: safeFactor });
+    };
+
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      const activeEl = document.activeElement;
+      if (activeEl?.tagName === 'INPUT' || activeEl?.tagName === 'TEXTAREA' || (activeEl as HTMLElement)?.isContentEditable) return;
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (editor.getEditingShapeId()) return;
+        const selectedIds = editor.getSelectedShapeIds();
+        if (selectedIds.length > 0) editor.deleteShapes(selectedIds);
+        e.preventDefault();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        if (e.shiftKey) editor.redo(); else editor.undo();
+        e.preventDefault();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y') {
+        editor.redo();
+        e.preventDefault();
+        return;
+      }
+      if (e.code === 'Space' && !e.repeat && !e.ctrlKey && !e.shiftKey && !e.altKey && editor.getCurrentToolId() !== 'hand') {
+        previousToolRef.current = editor.getCurrentToolId();
+        editor.setCurrentTool('hand');
+      }
+    };
+
+    const handleKeyUp = (e: globalThis.KeyboardEvent) => {
+      if (e.code === 'Space' && editor.getCurrentToolId() === 'hand') {
+        editor.setCurrentTool(previousToolRef.current);
+      }
+    };
+
+    let touchStartTime = 0;
+    let initialTouches: { id: number, x: number, y: number }[] = [];
+    let touchMoving = false;
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2 || e.touches.length === 3) {
+        touchStartTime = Date.now();
+        touchMoving = false;
+        initialTouches = Array.from(e.touches).map(t => ({ id: t.identifier, x: t.clientX, y: t.clientY }));
+      } else initialTouches = [];
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (initialTouches.length > 0) {
+        for (let i = 0; i < e.touches.length; i++) {
+          const t = e.touches[i];
+          const initial = initialTouches.find(it => it.id === t.identifier);
+          if (initial && Math.hypot(t.clientX - initial.x, t.clientY - initial.y) > 10) {
+            touchMoving = true;
+            break;
+          }
+        }
+      }
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (initialTouches.length > 0 && e.touches.length === 0) {
+        if (Date.now() - touchStartTime < 300 && !touchMoving) {
+          if (initialTouches.length === 2) editor.undo(); else if (initialTouches.length === 3) editor.redo();
+        }
+        initialTouches = [];
+      }
+    };
+
+    container.addEventListener('pointerdown', handlePointerDownCapture, { capture: true });
+    container.addEventListener('dblclick', handleDoubleClick);
+    container.addEventListener('pointerdown', handlePointerDown, { capture: true });
+    container.addEventListener('pointermove', handlePointerMove);
+    container.addEventListener('pointerup', handlePointerUp);
+    container.addEventListener('wheel', handleWheel, { passive: false, capture: true });
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    container.addEventListener('touchstart', handleTouchStart, { passive: true });
+    container.addEventListener('touchmove', handleTouchMove, { passive: true });
+    container.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+    return () => {
+      container.removeEventListener('pointerdown', handlePointerDownCapture, { capture: true });
+      container.removeEventListener('dblclick', handleDoubleClick);
+      container.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+      container.removeEventListener('pointermove', handlePointerMove);
+      container.removeEventListener('pointerup', handlePointerUp);
+      container.removeEventListener('wheel', handleWheel, { capture: true } as any);
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      container.removeEventListener('touchstart', handleTouchStart);
+      container.removeEventListener('touchmove', handleTouchMove);
+      container.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [editor, manualTool, userPrefs, lastGeoToolRef, parentRef, setIsLockingUI]);
+};

--- a/src/hooks/useDraggableWithBounds.ts
+++ b/src/hooks/useDraggableWithBounds.ts
@@ -1,0 +1,113 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface UseDraggableWithBoundsReturn {
+  position: Position;
+  setPosition: React.Dispatch<React.SetStateAction<Position>>;
+  handlePointerDown: (e: React.PointerEvent) => void;
+  hasMoved: React.MutableRefObject<boolean>;
+  isDragging: boolean;
+}
+
+/**
+ * Hook for making an element draggable within window bounds.
+ * Handles pointer events, movement detection, and boundary constraints.
+ */
+export const useDraggableWithBounds = (
+  initialPosition: Position,
+  width: number,
+  height: number
+): UseDraggableWithBoundsReturn => {
+  const [position, setPosition] = useState(initialPosition);
+  const [isDraggingState, setIsDraggingState] = useState(false);
+  const isDragging = useRef(false);
+  const hasMoved = useRef(false);
+  const startPos = useRef({ x: 0, y: 0 });
+  const itemStartPos = useRef({ x: 0, y: 0 });
+
+  const clamp = (val: number, min: number, max: number) => Math.min(Math.max(val, min), max);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    hasMoved.current = false;
+    // Only left click for mouse; all pointer types for touch/pen
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+
+    // Don't drag if the event comes from the opacity slider or other range inputs
+    const target = e.target as HTMLElement;
+    if (target.classList.contains('opacitySlider') ||
+      target.closest('.opacityRow') ||
+      (target instanceof HTMLInputElement && target.type === 'range')) {
+      return;
+    }
+
+    isDragging.current = true;
+    setIsDraggingState(true);
+    hasMoved.current = false;
+    startPos.current = { x: e.clientX, y: e.clientY };
+    itemStartPos.current = position;
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+
+    // Capture the pointer to ensure we get events even if it leaves the element
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: PointerEvent) => {
+    if (!isDragging.current) return;
+
+    const dx = e.clientX - startPos.current.x;
+    const dy = e.clientY - startPos.current.y;
+
+    // Threshold for "drag vs click": Increased to 10px to avoid accidental nudges
+    if (!hasMoved.current && (Math.abs(dx) > 10 || Math.abs(dy) > 10)) {
+      hasMoved.current = true;
+    }
+
+    // Only update position IF we have moved beyond the threshold
+    if (hasMoved.current) {
+      const newX = clamp(itemStartPos.current.x + dx, 0, window.innerWidth - width);
+      const newY = clamp(itemStartPos.current.y + dy, 0, window.innerHeight - height);
+      setPosition({ x: newX, y: newY });
+    }
+  };
+
+  const handlePointerUp = (e: PointerEvent) => {
+    isDragging.current = false;
+    setIsDraggingState(false);
+    document.removeEventListener('pointermove', handlePointerMove);
+    document.removeEventListener('pointerup', handlePointerUp);
+
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // Ignore if already released or invalid
+    }
+  };
+
+  // Adjust position on resize OR dimension change (e.g. collapse/expand) to keep it in bounds
+  useEffect(() => {
+    setPosition(p => ({
+      x: clamp(p.x, 0, window.innerWidth - width),
+      y: clamp(p.y, 0, window.innerHeight - height)
+    }));
+  }, [width, height]);
+
+  // Window resize separate listener
+  useEffect(() => {
+    const handleResize = () => {
+      setPosition(p => ({
+        x: clamp(p.x, 0, window.innerWidth - width),
+        y: clamp(p.y, 0, window.innerHeight - height)
+      }));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [width, height]);
+
+  return { position, setPosition, handlePointerDown, hasMoved, isDragging: isDraggingState };
+};

--- a/src/hooks/useEraserOverride.ts
+++ b/src/hooks/useEraserOverride.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { Editor } from 'tldraw';
+
+export const useEraserOverride = (editor: Editor) => {
+  useEffect(() => {
+    if (!editor) return;
+
+    const originalIsErasable = (editor as any).isShapeErasable ? (editor as any).isShapeErasable.bind(editor) : null;
+
+    // Try both new and old names just in case
+    // eslint-disable-next-line react-hooks/immutability
+    (editor as any).isErasable = (shape: any) => {
+      if (editor.getCurrentToolId() === 'eraser') return shape.type === 'draw';
+      return originalIsErasable ? originalIsErasable(shape) : true;
+    };
+    (editor as any).isShapeErasable = (editor as any).isErasable;
+
+    return () => {
+      // Restore
+      if (editor) {
+        if (originalIsErasable) {
+          (editor as any).isErasable = originalIsErasable;
+          (editor as any).isShapeErasable = originalIsErasable;
+        } else {
+          delete (editor as any).isErasable;
+          delete (editor as any).isShapeErasable;
+        }
+      }
+    };
+  }, [editor]);
+};

--- a/src/hooks/useLongPressBlocker.ts
+++ b/src/hooks/useLongPressBlocker.ts
@@ -1,0 +1,107 @@
+import { useEffect } from 'react';
+import { Editor } from 'tldraw';
+
+export const useLongPressBlocker = (editor: Editor) => {
+  useEffect(() => {
+    const container = editor.getContainer();
+    if (!container) return;
+
+    const LONG_PRESS_DURATION = 600;
+    const MOVEMENT_THRESHOLD = 10;
+    let longpressTimer: any = null;
+    let longpressStart: { x: number; y: number; target: EventTarget | null } | null = null;
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if ((e.pointerType === 'touch' || e.pointerType === 'pen') &&
+        editor.getCurrentToolId() === 'select' &&
+        !editor.getEditingShapeId() &&
+        e.button === 0) {
+        longpressStart = { x: e.clientX, y: e.clientY, target: e.target };
+        longpressTimer = setTimeout(() => {
+          if (longpressStart) {
+            const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+              (window.navigator as any).standalone ||
+              document.referrer.includes('android-app://');
+
+            if (isStandalone) {
+              const blocker = document.createElement('div');
+              Object.assign(blocker.style, {
+                position: 'fixed', inset: '0', zIndex: '100000',
+                backgroundColor: 'transparent', pointerEvents: 'auto', touchAction: 'none'
+              });
+
+              let isRemoving = false;
+              const cleanup = () => {
+                if (blocker.parentNode) document.body.removeChild(blocker);
+                ['pointerdown', 'pointerup', 'touchend', 'click', 'contextmenu'].forEach(ev =>
+                  window.removeEventListener(ev, handleEvent, { capture: true })
+                );
+              };
+
+              const handleEvent = (ev: any) => {
+                const x = ev.clientX ?? ev.touches?.[0]?.clientX ?? 0;
+                const y = ev.clientY ?? ev.touches?.[0]?.clientY ?? 0;
+                if ((ev.type === 'pointerdown' || ev.type === 'touchstart') && isRemoving) {
+                  if (longpressStart && Math.hypot(x - longpressStart.x, y - longpressStart.y) > 40) {
+                    cleanup(); return;
+                  }
+                }
+                ev.preventDefault();
+                ev.stopImmediatePropagation();
+                if (['pointerup', 'touchend', 'click'].includes(ev.type)) {
+                  if (!isRemoving) {
+                    isRemoving = true;
+                    setTimeout(cleanup, 250);
+                  }
+                }
+              };
+
+              ['pointerdown', 'pointerup', 'touchend', 'click', 'contextmenu'].forEach(ev =>
+                window.addEventListener(ev, handleEvent, { capture: true })
+              );
+              document.body.appendChild(blocker);
+            }
+
+            const contextMenuEvent = new MouseEvent('contextmenu', {
+              bubbles: true, cancelable: true,
+              clientX: longpressStart.x, clientY: longpressStart.y,
+            });
+            longpressStart.target?.dispatchEvent(contextMenuEvent);
+            longpressStart = null;
+          }
+        }, LONG_PRESS_DURATION);
+      }
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (longpressStart && longpressTimer) {
+        if (Math.hypot(e.clientX - longpressStart.x, e.clientY - longpressStart.y) > MOVEMENT_THRESHOLD) {
+          clearTimeout(longpressTimer);
+          longpressTimer = null;
+          longpressStart = null;
+        }
+      }
+    };
+
+    const handlePointerUp = () => {
+      if (longpressTimer) {
+        clearTimeout(longpressTimer);
+        longpressTimer = null;
+        longpressStart = null;
+      }
+    };
+
+    container.addEventListener('pointerdown', handlePointerDown);
+    container.addEventListener('pointermove', handlePointerMove);
+    container.addEventListener('pointerup', handlePointerUp);
+    container.addEventListener('pointercancel', handlePointerUp);
+
+    return () => {
+      container.removeEventListener('pointerdown', handlePointerDown);
+      container.removeEventListener('pointermove', handlePointerMove);
+      container.removeEventListener('pointerup', handlePointerUp);
+      container.removeEventListener('pointercancel', handlePointerUp);
+      if (longpressTimer) clearTimeout(longpressTimer);
+    };
+  }, [editor]);
+};

--- a/src/hooks/usePageLoading.ts
+++ b/src/hooks/usePageLoading.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react';
+import { Editor, DefaultColorStyle, DefaultSizeStyle, DefaultFontStyle, DefaultTextAlignStyle, DefaultDashStyle, DefaultFillStyle, GeoShapeGeoStyle } from 'tldraw';
+import { opfs } from '../lib/opfs';
+import { syncLog } from '../lib/debugLog';
+
+export const usePageLoading = (
+  editor: Editor,
+  pageId: string,
+  pageVersion: number,
+  lastModifier: string | undefined,
+  clientId: string,
+  userPrefs: any,
+  sidebarColumns: number,
+  leftHandedMode: boolean,
+  isLoadingRef: React.MutableRefObject<boolean>
+) => {
+  const lastLoadRef = useRef<{ pageId: string | null; version: number | null }>({ pageId: null, version: null });
+
+  useEffect(() => {
+    if (!pageId) return;
+
+    const loadPage = async () => {
+      isLoadingRef.current = true; // Prevent saves during load
+
+      const json = await opfs.loadFile(`page-${pageId}.tldr`);
+      if (json && json !== '{}' && json !== '') {
+        try {
+          const snapshot = JSON.parse(json);
+          editor.loadSnapshot(snapshot);
+
+          // Denormalize camera: Restore position relative to the center of the NEW viewport
+          if (snapshot.camera) {
+            const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+            const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
+            const viewportHalfHeight = window.innerHeight / 2;
+
+            // visualX = diskX + (center / zoom)
+            const actualX = snapshot.camera.x + (viewportCenter / snapshot.camera.z);
+            const actualY = snapshot.camera.y + (viewportHalfHeight / snapshot.camera.z);
+
+            syncLog(`📥 [CENTERING] Restoring: DiskX ${snapshot.camera.x.toFixed(0)} -> VisualX ${actualX.toFixed(0)}`);
+            editor.setCamera({ x: actualX, y: actualY, z: snapshot.camera.z });
+          } else {
+            // Document exists but no camera? Default to centered origin
+            const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+            const viewportHalfWidth = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
+            const viewportHalfHeight = window.innerHeight / 2;
+            const centerX = viewportHalfWidth;
+            const centerY = viewportHalfHeight;
+            editor.setCamera({ x: centerX, y: centerY, z: 1 });
+          }
+
+          // 💡 PRIMING with User Preferences
+          editor.setStyleForNextShapes(DefaultColorStyle, userPrefs.textColor);
+          editor.setStyleForNextShapes(DefaultSizeStyle, userPrefs.textSize);
+          editor.setStyleForNextShapes(DefaultFontStyle, userPrefs.textFont);
+          editor.setStyleForNextShapes(DefaultTextAlignStyle, userPrefs.textAlign === 'justify' ? 'start' : userPrefs.textAlign as any);
+          editor.setStyleForNextShapes(DefaultDashStyle, userPrefs.dashStyle as any);
+          editor.setStyleForNextShapes(DefaultFillStyle, userPrefs.fillStyle as any);
+          editor.setStyleForNextShapes(GeoShapeGeoStyle, userPrefs.lastUsedGeo as any);
+        } catch (e) {
+          console.error("Failed to load snapshot", e);
+        }
+      } else {
+        // New or Empty page: EXPLICITLY clear shapes to prevent bleed
+        const shapeIds = editor.getCurrentPageShapeIds();
+        if (shapeIds.size > 0) {
+          editor.deleteShapes(Array.from(shapeIds));
+        }
+
+        // Center on origin (0,0) taking sidebar into account
+        const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+        const viewportHalfWidth = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
+        const viewportHalfHeight = window.innerHeight / 2;
+        const centerX = viewportHalfWidth;
+        const centerY = viewportHalfHeight;
+        editor.setCamera({ x: centerX, y: centerY, z: 1 });
+      }
+
+      // Delay to ensure all load-related events have settled
+      // 500ms provides a safer buffer against false-positive auto-saves
+      setTimeout(() => {
+        isLoadingRef.current = false;
+      }, 500);
+    };
+
+    const isNewPage = pageId !== lastLoadRef.current.pageId;
+    // Reload if: 1. It's a version change AND (modifier is different OR modifier is unknown)
+    const isRemoteChange = !isNewPage && pageVersion !== lastLoadRef.current.version && (!lastModifier || lastModifier !== clientId);
+
+    if (isNewPage || isRemoteChange) {
+      loadPage();
+      lastLoadRef.current = { pageId, version: pageVersion };
+    }
+
+  }, [editor, pageId, pageVersion, lastModifier, clientId, userPrefs, sidebarColumns, leftHandedMode, isLoadingRef]);
+};

--- a/src/hooks/usePagePersistence.ts
+++ b/src/hooks/usePagePersistence.ts
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from 'react';
+import { Editor } from 'tldraw';
+import { opfs } from '../lib/opfs';
+import { syncLog } from '../lib/debugLog';
+import { useFileSystemStore } from '../store/fileSystemStore';
+
+export const usePagePersistence = (
+  editor: Editor,
+  pageId: string,
+  sidebarColumns: number,
+  leftHandedMode: boolean,
+  isLoadingRef: React.MutableRefObject<boolean>
+) => {
+  const hasUnsavedChangesRef = useRef(false);
+  const lastCameraRef = useRef({ x: 0, y: 0, z: 1 });
+
+  useEffect(() => {
+    if (!pageId) return;
+
+    const save = async () => {
+      // No guardar mientras se está cargando para evitar pisotear datos
+      if (isLoadingRef.current) {
+        syncLog(`[CENTERING] 🚫 Guardado cancelado: Cargando página.`);
+        return;
+      }
+
+      if (!hasUnsavedChangesRef.current) {
+        return;
+      }
+
+      const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+      const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
+      const viewportHalfHeight = window.innerHeight / 2;
+
+      const fullSnapshot = editor.getSnapshot();
+
+      // Obtener todos los registros directamente del store (método más fiable en v4)
+      const allRecordsArray = editor.store.allRecords();
+
+      // Filtramos records transitorios
+      const filteredRecords = allRecordsArray.filter(r =>
+        r.typeName !== 'instance' &&
+        r.typeName !== 'pointer' &&
+        r.typeName !== 'camera'
+      );
+
+      // Convertimos el array de nuevo a un objeto Record<ID, Record>
+      const filteredStore = Object.fromEntries(filteredRecords.map(r => [r.id, r]));
+
+      const { x, y, z } = editor.getCamera();
+      // Normalización de cámara
+      const normalizedX = x - (viewportCenter / z);
+      const normalizedY = y - (viewportHalfHeight / z);
+
+      // Creamos el snapshot con la estructura que tldraw espera
+      const filteredSnapshot = {
+        store: filteredStore,
+        schema: (fullSnapshot as any).schema || (editor.store as any).schema?.serialize() || {},
+        camera: { x: normalizedX, y: normalizedY, z }
+      };
+
+      try {
+        const serialized = JSON.stringify(filteredSnapshot);
+        await opfs.saveFile(`page-${pageId}.tldr`, serialized);
+
+        // Señalizar cambio para sincronización
+        useFileSystemStore.getState().markPageDirty(pageId);
+
+        syncLog(`🔶 [CENTERING] Disco guardado: ${filteredRecords.length} reg. Pos: {x: ${normalizedX.toFixed(0)}, y: ${normalizedY.toFixed(0)}}`);
+      } catch (err) {
+        console.error(`[CENTERING] ❌ ERROR AL ESCRIBIR EN DISCO:`, err);
+      }
+
+      hasUnsavedChangesRef.current = false;
+    };
+
+    // Register this save function to be called before sync
+    useFileSystemStore.getState().registerActivePageSaver(save);
+
+    let timeout: any;
+    const handleSave = () => {
+      hasUnsavedChangesRef.current = true;
+      clearTimeout(timeout);
+      timeout = setTimeout(save, 500);
+    };
+
+    const cleanup = editor.store.listen((event) => {
+      // Ignore events during page load
+      if (isLoadingRef.current) return;
+
+      const { added, updated, removed } = event.changes;
+
+      // Check if any relevant records (shapes or camera) were modified
+      const hasRelevantChanges = Object.keys(added).length > 0 ||
+        Object.keys(removed).length > 0 ||
+        Object.values(updated).some(([, to]: any) => {
+          const type = to.typeName;
+
+          if (type === 'shape' && event.source === 'user') {
+            return true;
+          }
+
+          if (type === 'camera') {
+            const cam = to;
+            const moved = cam.x !== lastCameraRef.current.x || cam.y !== lastCameraRef.current.y || cam.z !== lastCameraRef.current.z;
+            if (moved) {
+              lastCameraRef.current = { x: cam.x, y: cam.y, z: cam.z };
+              return true;
+            }
+          }
+
+          return false;
+        });
+
+      if (hasRelevantChanges) {
+        handleSave();
+      }
+    });
+
+    return () => {
+      cleanup();
+      // If we have unsaved changes when the component or pageId changes, trigger one last save
+      if (hasUnsavedChangesRef.current) {
+        save();
+      }
+      clearTimeout(timeout);
+    };
+  }, [editor, pageId, sidebarColumns, leftHandedMode, isLoadingRef]);
+};

--- a/src/hooks/useRecenter.ts
+++ b/src/hooks/useRecenter.ts
@@ -1,0 +1,39 @@
+import { Editor } from 'tldraw';
+
+export const useRecenter = (editor: Editor, sidebarColumns: number, leftHandedMode: boolean) => {
+  const handleRecenter = () => {
+    if (!editor) return;
+    const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+    const viewportCenter = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : (window.innerWidth + sidebarWidth) / 2;
+    const viewportHalfHeight = window.innerHeight / 2;
+    const { z } = editor.getCamera();
+    editor.setCamera({ x: viewportCenter / z, y: viewportHalfHeight / z, z }, { animation: { duration: 300 } });
+  };
+
+  const handleRecenterAll = () => {
+    if (!editor) return;
+    const bounds = editor.getCurrentPageBounds();
+    if (!bounds) return;
+
+    const sidebarWidth = sidebarColumns > 0 ? (250 * sidebarColumns + 24) : 0;
+    const padding = 64;
+    const availableWidth = window.innerWidth - sidebarWidth - padding;
+    const availableHeight = window.innerHeight - padding;
+
+    if (availableWidth <= 0 || availableHeight <= 0) return;
+
+    const zoomX = availableWidth / bounds.w;
+    const zoomY = availableHeight / bounds.h;
+    const z = Math.min(zoomX, zoomY, 1);
+
+    const targetX = leftHandedMode ? (window.innerWidth - sidebarWidth) / 2 : sidebarWidth + (window.innerWidth - sidebarWidth) / 2;
+    const targetY = window.innerHeight / 2;
+
+    const camX = (targetX / z) - (bounds.x + bounds.w / 2);
+    const camY = (targetY / z) - (bounds.y + bounds.h / 2);
+
+    editor.setCamera({ x: camX, y: camY, z }, { animation: { duration: 300 } });
+  };
+
+  return { handleRecenter, handleRecenterAll };
+};

--- a/src/hooks/useSidebarPanning.ts
+++ b/src/hooks/useSidebarPanning.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+import { Editor } from 'tldraw';
+
+export const useSidebarPanning = (editor: Editor, sidebarColumns: number, leftHandedMode: boolean) => {
+  const lastSidebarColumnsRef = useRef(sidebarColumns);
+
+  useEffect(() => {
+    if (lastSidebarColumnsRef.current === sidebarColumns) return;
+
+    const columnWidth = 250;
+    const margin = 12;
+    const prevWidth = lastSidebarColumnsRef.current > 0 ? (columnWidth * lastSidebarColumnsRef.current + margin * 2) : 0;
+    const currWidth = sidebarColumns > 0 ? (columnWidth * sidebarColumns + margin * 2) : 0;
+    const diff = currWidth - prevWidth;
+
+    const { x, y, z } = editor.getCamera();
+    // Shift camera by half the diff / zoom to keep content centered in the remaining visible space
+    // If sidebar on RIGHT expands, shift camera to the LEFT (invert diff)
+    const shiftX = leftHandedMode ? -diff : diff;
+    editor.setCamera({ x: x + (shiftX / 2) / z, y, z }, { animation: { duration: 300 } });
+
+    lastSidebarColumnsRef.current = sidebarColumns;
+  }, [editor, sidebarColumns, leftHandedMode]);
+};

--- a/src/hooks/useStyleMemory.ts
+++ b/src/hooks/useStyleMemory.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { Editor, DefaultDashStyle } from 'tldraw';
+
+export const useStyleMemory = (editor: Editor) => {
+  const lastShapesDashRef = useRef<string>('solid');
+  const lastPencilDashRef = useRef<string>('draw');
+  const lastGeoToolRef = useRef<string>('geo');
+
+  useEffect(() => {
+    // Sync memory with current editor state when styles change
+    const unlisten = editor.store.listen(() => {
+      const currentDash = editor.getStyleForNextShape(DefaultDashStyle) as string;
+      const currentTool = editor.getCurrentToolId();
+      if (currentTool === 'geo' || currentTool === 'arrow' || currentTool === 'line' || currentTool === 'note') {
+        lastShapesDashRef.current = currentDash;
+        if (currentTool !== 'note') lastGeoToolRef.current = currentTool;
+      } else if (currentTool === 'draw') {
+        lastPencilDashRef.current = currentDash;
+      }
+    }, { source: 'user', scope: 'session' });
+    return () => unlisten();
+  }, [editor]);
+
+  return {
+    lastShapesDashRef,
+    lastPencilDashRef,
+    lastGeoToolRef
+  };
+};

--- a/src/hooks/useTouchPanning.ts
+++ b/src/hooks/useTouchPanning.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import { Editor } from 'tldraw';
+import { syncLog } from '../lib/debugLog';
+import { useFileSystemStore } from '../store/fileSystemStore';
+
+export const useTouchPanning = (
+  editor: Editor
+) => {
+  const lastToolBeforeEraserRef = useRef<string | null>(null);
+  const autoSwitchedEraserRef = useRef(false);
+
+  useEffect(() => {
+    const container = editor.getContainer();
+    if (!container) return;
+
+    const activeTouchIds = new Set<number>();
+    let previousTool: string | null = null;
+    let didSwitchToHand = false;
+
+    const handlePointerDown = (e: PointerEvent) => {
+
+      if (document.body.classList.contains('rename-overlay-active')) return;
+
+      const target = e.target as HTMLElement;
+      if (target.closest?.('[data-is-ui="true"]')) return;
+
+      const { penMode } = useFileSystemStore.getState();
+      const currentTool = editor.getCurrentToolId();
+
+      if (e.pointerType === 'pen') {
+        if (e.buttons === 32 || e.button === 5) {
+          if (currentTool !== 'eraser') {
+            syncLog(`✏️ [PENCIL] Eraser mode detected`);
+            lastToolBeforeEraserRef.current = currentTool;
+            autoSwitchedEraserRef.current = true;
+            editor.setCurrentTool('eraser');
+          }
+        } else if (e.buttons === 1) {
+          if (autoSwitchedEraserRef.current && currentTool === 'eraser') {
+            syncLog(`✏️ [PENCIL] Normal mode restored`);
+            const toolToRestore = lastToolBeforeEraserRef.current || 'draw';
+            editor.setCurrentTool(toolToRestore);
+            autoSwitchedEraserRef.current = false;
+            lastToolBeforeEraserRef.current = null;
+          }
+        }
+      }
+
+      if (penMode && (currentTool === 'draw' || currentTool === 'eraser') && e.pointerType !== 'pen') {
+        if (activeTouchIds.size === 0) {
+          previousTool = currentTool;
+          editor.setCurrentTool('hand');
+          didSwitchToHand = true;
+        }
+        activeTouchIds.add(e.pointerId);
+      }
+    };
+
+    const handlePointerUp = (e: PointerEvent) => {
+      if (document.body.classList.contains('rename-overlay-active')) return;
+      if (activeTouchIds.has(e.pointerId)) {
+        activeTouchIds.delete(e.pointerId);
+        if (activeTouchIds.size === 0 && didSwitchToHand) {
+          const toolToRestore = previousTool;
+          didSwitchToHand = false;
+          previousTool = null;
+          requestAnimationFrame(() => {
+            if (toolToRestore && editor && editor.getCurrentToolId() === 'hand') {
+              editor.setCurrentTool(toolToRestore);
+            }
+          });
+        }
+      }
+    };
+
+    container.addEventListener('pointerdown', handlePointerDown, { capture: true });
+    window.addEventListener('pointerup', handlePointerUp, { capture: true });
+    window.addEventListener('pointercancel', handlePointerUp, { capture: true });
+
+    return () => {
+      container.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+      window.removeEventListener('pointerup', handlePointerUp, { capture: true });
+      window.removeEventListener('pointercancel', handlePointerUp, { capture: true });
+    };
+  }, [editor]);
+
+  return { lastToolBeforeEraserRef, autoSwitchedEraserRef };
+};


### PR DESCRIPTION
## Description
Split the monolithic components `CanvasArea.tsx` and `Bubble.tsx` into smaller, more maintainable modules.

### CanvasArea Refactoring
- Extracted hooks to `src/hooks/`:
  - `useCanvasSync.ts` - sync state management
  - `usePageLoading.ts` - page loading logic
  - `usePagePersistence.ts` - page persistence
  - `useCanvasKeyboardShortcuts.ts` - keyboard handling
  - `useImagePasting.ts` - image paste handling
  - `useShapeDropping.ts` - drag & drop shapes
- Created `CanvasCore.tsx` for core canvas rendering
- Reduced main component from ~800 to manageable size

### Bubble Refactoring
- Extracted `useDraggableWithBounds.ts` hook
- Created `icons/` folder (ScribbleIcon, TrapezoidIcon)
- Created `utils/richTextUtils.ts`
- Split UI into 5 section components:
  - `BubbleCollapsed.tsx`
  - `BubbleTextSection.tsx`
  - `BubbleShapeSection.tsx`
  - `BubbleStrokeSection.tsx`
  - `BubbleFillSection.tsx`
- Reduced from ~1448 to ~740 lines (~50% reduction)

## Type of Change
- [ ] Feature/Enhancement
- [ ] Bug Fix
- [ ] Documentation
- [x] Internal/Chore
- [ ] Tests

## Related Issue
Closes #58

## Changelog Entry
Refactored CanvasArea and Bubble components into modular sub-components for improved maintainability.

## Testing
- Build passes (`npm run build`)
- Lint passes (`npm run lint`)
- Manual testing of all UI components