### PR TITLE
Ensure tldraw watermark visibility for license compliance

### DIFF
--- a/src/components/Canvas/CanvasArea.module.css
+++ b/src/components/Canvas/CanvasArea.module.css
@@ -204,16 +204,3 @@
   content: '→';
   order: 2;
 }
-
-/* Hide Tldraw Watermark */
-:global(.tl-watermark),
-:global(.tl-watermark__container),
-:global(.tl-watermark_link),
-:global(.tl-ui-watermark),
-:global(.tl-watermark_SEE-LICENSE),
-:global([data-testid="tl-watermark-licensed"]) {
-  display: none !important;
-  opacity: 0 !important;
-  visibility: hidden !important;
-  pointer-events: none !important;
-}

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -182,15 +182,10 @@ export const CanvasArea = () => {
   return (
     <div className={styles.wrapper} ref={parentRef} style={{ '--sidebar-columns': sidebarColumns } as React.CSSProperties}>
       <style>{`
-        .tl-watermark, 
-        .tl-ui-watermark, 
-        .tl-watermark__container,
+        /* Reposition tldraw watermark to avoid overlapping with recenter button */
         .tl-watermark_SEE-LICENSE,
         [data-testid="tl-watermark-licensed"] { 
-          display: none !important; 
-          opacity: 0 !important;
-          visibility: hidden !important;
-          pointer-events: none !important;
+          right: 80px !important;
         }
       `}</style>
       {!isSidebarOpen && (

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -186,6 +186,7 @@ export const CanvasArea = () => {
         .tl-watermark_SEE-LICENSE,
         [data-testid="tl-watermark-licensed"] { 
           right: 80px !important;
+          bottom: 16px !important;
         }
       `}</style>
       {!isSidebarOpen && (


### PR DESCRIPTION
## Description

This PR ensures compliance with tldraw's license terms regarding "Technical enforcement" and watermark visibility.

Instead of hiding the watermark (which violates the license terms), this PR repositions it to avoid overlapping with the UI:

-   **Reverted watermark hiding**: Removed CSS rules that set `display: none` or `opacity: 0` on the watermark.
-   **Repositioned watermark**: Moved the watermark to the left of the recenter button (`right: 80px`, `bottom: 16px`) to ensure it is visible but does not obstruct interaction.

The "MADE WITH TLDRAW" badge in the Settings menu is retained as an additional attribution.

## Type of Change

-   [ ] Feature/Enhancement
-   [x] Bug Fix (License Compliance)
-   [ ] Documentation
-   [ ] Internal/Chore
-   [ ] Tests

## Related Issue

Follow-up to PR #95.

## Changelog Entry

-   **Fix**: Repositioned tldraw watermark to be visible (license compliance) instead of hiding it, placing it to the left of the recenter button.

## Testing

-   Verified watermark is visible on the canvas.
-   Verified watermark does not overlap with the recenter button.
-   Verified watermark is vertically aligned with the button.
