### PR TITLE
feat: persist bubble state & fix boundary bugs

### DIFF
--- a/src/store/userPreferencesStore.ts
+++ b/src/store/userPreferencesStore.ts
@@ -27,6 +27,10 @@ interface UserPreferencesState {
   shapeFillColor: string;
   shapeFillOpacity: string;
 
+  // UI State (Persisted locally only)
+  bubbleCollapsed: boolean;
+  bubblePosition: { x: number; y: number } | null;
+
   lastUsedGeo: string;
   lastActiveTool: string;
 
@@ -48,7 +52,7 @@ export const useUserPreferencesStore = create<UserPreferencesState>()(
       textStrike: false,
 
       drawColor: 'black',
-      drawSize: 'm',
+      drawSize: 's', // Changed from 'm' to 's' (Very Small/Small)
       drawOpacity: '1',
       drawDash: 'solid',
 
@@ -60,8 +64,12 @@ export const useUserPreferencesStore = create<UserPreferencesState>()(
       shapeFillColor: 'black',
       shapeFillOpacity: '0.1',
 
+      // UI Defaults
+      bubbleCollapsed: false,
+      bubblePosition: null, // Will use default in component if null
+
       lastUsedGeo: 'rectangle',
-      lastActiveTool: 'draw',
+      lastActiveTool: 'draw', // Default to draw (Pencil)
 
       updatePreferences: (prefs) => set((state) => ({ ...state, ...prefs })),
     }),


### PR DESCRIPTION
## Description
Implemented persistent state for the Bubble UI (position & collapse) and Tool configurations (Color, Size, Active Tool) using OPFS and local storage adjustments.
Additionally, implemented a robust `ResizeObserver` based solution to handle dynamic bubble height, ensuring it always stays within the window boundaries regardless of the selected tool or window size.

## Type of Change
- [x] Feature/Enhancement
- [x] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests

## Related Issue
Fixes #102

## Changelog Entry
Persist Bubble position, collapse state, and active tool configuration. Fixed issues with drag boundaries and dynamic height overflow.

## Testing
- Verified bubble position persists after reload.
- Verified active tool (Pencil/Text/Shapes) persists after reload.
- Verified drag logic respects window boundaries.
- Verified dynamic height adjustment works for all tools and window resize events.