### PR TITLE
fix(styles): fix initial configuration sync and tool restoration issues

### DIFF
--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -152,6 +152,22 @@ export const Bubble = track(({ activeTool, onSelectTool, onUpload, onAddUrl }: B
     align: textAlign
   });
 
+  useEffect(() => {
+    const editingId = editor.getEditingShapeId();
+    if (!editingId) {
+      setRichStats({
+        bold: textBold,
+        italic: textItalic,
+        underline: textUnderline,
+        strike: textStrike,
+        font: textFont,
+        size: textSize,
+        color: textColor,
+        align: textAlign
+      });
+    }
+  }, [editor, textBold, textItalic, textUnderline, textStrike, textFont, textSize, textColor, textAlign]);
+
   // Sync state with cursor position
   useEffect(() => {
     const editingId = editor.getEditingShapeId();
@@ -729,18 +745,53 @@ export const Bubble = track(({ activeTool, onSelectTool, onUpload, onAddUrl }: B
   // No early return here anymore as it contains the toolbar
 
 
-  const currentSize = isTextMode ? richStats.size : ((getStyle(DefaultSizeStyle, 'm') as string) || richStats.size || 'm');
-  const currentColor = isTextMode ? richStats.color : ((getStyle(DefaultColorStyle, 'black') as string) || richStats.color || 'black');
+
+  const currentSize = (() => {
+    if (isTextMode) return richStats.size;
+    if (activeTool === 'draw') return drawSize;
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return shapeSize;
+    return (getStyle(DefaultSizeStyle, 'm') as string) || 'm';
+  })();
+
+  const currentColor = (() => {
+    if (isTextMode) return richStats.color;
+    if (activeTool === 'draw') return drawColor;
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return shapeColor;
+    return (getStyle(DefaultColorStyle, 'black') as string) || 'black';
+  })();
+
   const currentFont = isTextMode ? richStats.font : ((getStyle(DefaultFontStyle, 'draw') as string) || richStats.font || 'draw');
 
   const currentGeo = (getStyle(GeoShapeGeoStyle, 'rectangle') as string);
-  const currentDash = (getStyle(DefaultDashStyle, 'solid') as string);
-  const currentFill = (getStyle(DefaultFillStyle, 'none') as string);
+
+  const currentDash = (() => {
+    if (activeTool === 'draw') return drawDash;
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return shapeDash;
+    return (getStyle(DefaultDashStyle, 'solid') as string);
+  })();
+
+  const currentFill = (() => {
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return shapeFill;
+    return (getStyle(DefaultFillStyle, 'none') as string);
+  })();
+
   const currentTldrawTool = editor.getCurrentToolId();
 
-  const currentFillColor = (getStyle(FillColorStyle, 'black') as string);
-  const currentFillOpacity = parseFloat(getStyle(FillOpacityStyle, '1') as string);
-  const currentStrokeOpacity = parseFloat(getStyle(StrokeOpacityStyle, '1') as string);
+  const currentFillColor = (() => {
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return shapeFillColor;
+    return (getStyle(FillColorStyle, 'black') as string);
+  })();
+
+  const currentFillOpacity = (() => {
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return parseFloat(shapeFillOpacity);
+    return parseFloat(getStyle(FillOpacityStyle, '1') as string);
+  })();
+
+  const currentStrokeOpacity = (() => {
+    if (activeTool === 'draw') return parseFloat(drawOpacity);
+    if (['geo', 'arrow', 'line', 'shapes'].includes(activeTool)) return parseFloat(shapeOpacity);
+    return parseFloat(getStyle(StrokeOpacityStyle, '1') as string);
+  })();
 
   const activeColorHex = colorsMap[currentColor] || theme.black.solid;
 

--- a/src/hooks/usePageLoading.ts
+++ b/src/hooks/usePageLoading.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Editor, DefaultColorStyle, DefaultSizeStyle, DefaultFontStyle, DefaultTextAlignStyle, DefaultDashStyle, DefaultFillStyle, GeoShapeGeoStyle } from 'tldraw';
+import { Editor, GeoShapeGeoStyle } from 'tldraw';
 import { opfs } from '../lib/opfs';
 import { syncLog } from '../lib/debugLog';
 import { useFileSystemStore } from '../store/fileSystemStore';
@@ -53,12 +53,10 @@ export const usePageLoading = (
           }
 
           // 💡 PRIMING with User Preferences
-          editor.setStyleForNextShapes(DefaultColorStyle, userPrefs.textColor);
-          editor.setStyleForNextShapes(DefaultSizeStyle, userPrefs.textSize);
-          editor.setStyleForNextShapes(DefaultFontStyle, userPrefs.textFont);
-          editor.setStyleForNextShapes(DefaultTextAlignStyle, userPrefs.textAlign === 'justify' ? 'start' : userPrefs.textAlign as any);
-          editor.setStyleForNextShapes(DefaultDashStyle, userPrefs.dashStyle as any);
-          editor.setStyleForNextShapes(DefaultFillStyle, userPrefs.fillStyle as any);
+          // 💡 PRIMING with User Preferences
+          // We defer specific style setting to the Bubble component or Tool initialization
+          // which knows the active tool. Setting generic defaults here (like textColor)
+          // overrides the correct tool settings (like drawColor) if initialized blindly.
           editor.setStyleForNextShapes(GeoShapeGeoStyle, userPrefs.lastUsedGeo as any);
         } catch (e) {
           console.error("Failed to load snapshot", e);


### PR DESCRIPTION
## Description
Fixed issue where initial tool styles were overwritten on load or reset to defaults incorrectly.
Unified style persistence in UserPreferencesStore.
Fixed active tool synchronization in Bubble component.
Fixed crash when reloading with Shape tool active.

## Type of Change
- [ ] Feature/Enhancement
- [x] Bug Fix
- [ ] Documentation
- [ ] Internal/Chore
- [ ] Tests

## Related Issue
Fixes #102

## Changelog Entry
Fixed tool configuration persistence and 'jump' on page load.

## Testing
Manual verification by user:
1. Reload with different tools selected (Pencil, Shapes, Text).
2. Verify styles (color, size) persist correctly.
3. Verify no crash on Shape tool reload.
4. Verify styles update correctly when changing tools.
Validated with 'npm run check'.