### PR TITLE
fix: restore tool toggle logic in collapsed bubble

### DIFF
--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -116,7 +116,9 @@ const CanvasInterface = track(({ pageId, pageVersion, lastModifier, clientId, pa
 
   const handleSelectTool = useCallback((tool: string) => {
     setManualTool(tool);
-    userPrefs.updatePreferences({ lastActiveTool: tool }); // Persist selection
+    if (tool !== 'eraser') {
+      userPrefs.updatePreferences({ lastActiveTool: tool }); // Persist selection
+    }
 
     if (['draw', 'eraser'].includes(tool)) editor.selectNone();
     editor.setEditingShape(null);


### PR DESCRIPTION
## Description
Fixes a regression where the collapsed bubble failed to toggle back to the previous tool after switching to the eraser. The issue was caused by `handleSelectTool` incorrectly updating the `lastActiveTool` preference when the eraser was selected, causing the toggle logic to read 'eraser' as the previous tool.

## Type of Change
- [x] Bug Fix

## Related Issue
Regression from recent persistence changes in Bubble component.

## Changelog Entry
Fix tool toggle functionality in collapsed bubble mode.

## Testing
Manual verification:
1. Select Pencil -> Collapse Bubble -> Click Bubble (Eraser) -> Click Bubble (Pencil) -> PASS.
2. Select Text -> Collapse Bubble -> Click Bubble (Eraser) -> Click Bubble (Text) -> PASS.
